### PR TITLE
Remove exception handling from PasswordStatusServiceImplBase.connect...ToObserver functions

### DIFF
--- a/grpc-kotlin-gen/src/main/resources/KtStub.mustache
+++ b/grpc-kotlin-gen/src/main/resources/KtStub.mustache
@@ -17,7 +17,7 @@ import kotlinx.coroutines.experimental.Deferred
 import kotlinx.coroutines.experimental.channels.LinkedListChannel
 import kotlinx.coroutines.experimental.channels.ReceiveChannel
 import kotlinx.coroutines.experimental.channels.SendChannel
-import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.experimental.runBlocking
 
 {{#deprecated}}@Deprecated("deprecated"){{/deprecated}}
 @javax.annotation.Generated(
@@ -103,27 +103,19 @@ object {{className}} {
 
   private fun <E> connectChannelToObserver(channel: ReceiveChannel<E>, observer: StreamObserver<E>) {
     // todo: specify coroutine context
-    launch {
-      try {
-        for (value in channel) {
-          observer.onNext(value)
-        }
-        observer.onCompleted()
-      } catch (t: Throwable) {
-        observer.onError(t)
+    runBlocking {
+      for (value in channel) {
+        observer.onNext(value)
       }
+      observer.onCompleted()
     }
   }
 
   private fun <E> connectDeferredToObserver(deferred: Deferred<E>, observer: StreamObserver<E>) {
     // todo: specify coroutine context
-    launch {
-      try {
-        observer.onNext(deferred.await())
-        observer.onCompleted()
-      } catch (t: Throwable) {
-        observer.onError(t)
-      }
+    runBlocking {
+      observer.onNext(deferred.await())
+      observer.onCompleted()
     }
   }
 


### PR DESCRIPTION
Also changed connect...ToObserver functions to user runBlocking rather than launch

Client will receive the same 'io.grpc.StatusRuntimeException: UNKNOWN', however the exception
gets propagated through interceptor and logged on the server.