### PR TITLE
Integrate CoroutineContext and Scope with generated server base

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,19 +112,17 @@ import kotlinx.coroutines.experimental.*
 import kotlinx.coroutines.experimental.channels.ReceiveChannel
 import kotlinx.coroutines.experimental.channels.produce
 
-class GreeterImpl : GreeterGrpcKt.GreeterImplBase() {
+class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
+    coroutineContext = newFixedThreadPoolContext(4, "server-pool")
+) {
 
-  private val pool = newFixedThreadPoolContext(4, "server-pool")
-
-  override fun greet(request: GreetRequest)
-      : Deferred<GreetReply> = GlobalScope.async(pool) {
+  override fun greet(request: GreetRequest) = async<GreetReply> {
     GreetReply.newBuilder()
         .setReply("Hello " + request.greeting)
         .build()
   }
 
-  override fun greetServerStream(request: GreetRequest)
-      : ReceiveChannel<GreetReply> = GlobalScope.produce(pool) {
+  override fun greetServerStream(request: GreetRequest) = produce<GreetReply> {
     send(GreetReply.newBuilder()
         .setReply("Hello ${request.greeting}!")
         .build())
@@ -133,8 +131,7 @@ class GreeterImpl : GreeterGrpcKt.GreeterImplBase() {
         .build())
   }
 
-  override fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>)
-      : Deferred<GreetReply> = GlobalScope.async(pool) {
+  override fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>) = async<GreetReply> {
     val greetings = mutableListOf<String>()
 
     for (request in requestChannel) {
@@ -146,23 +143,18 @@ class GreeterImpl : GreeterGrpcKt.GreeterImplBase() {
         .build()
   }
 
-  override fun greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>)
-      : ReceiveChannel<GreetReply> = GlobalScope.produce(pool) {
+  override fun greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) = produce<GreetReply> {
     var count = 0
-    val queue = mutableListOf<Job>()
 
     for (request in requestChannel) {
       val n = count++
-      val job = GlobalScope.launch(pool) {
+      launch {
         delay(1000)
         send(GreetReply.newBuilder()
             .setReply("Yo #$n ${request.greeting}")
             .build())
       }
-      queue.add(job)
     }
-
-    queue.forEach { it.join() }
   }
 }
 ```
@@ -198,19 +190,19 @@ fun main(args: Array<String>) {
 
     // === Client streaming call ==================================================================
 
-    val (reqMany, resOne) = greeter.greetClientStream()
-    reqMany.send(req("Caroline"))
-    reqMany.send(req("David"))
-    reqMany.close()
-    val oneReply = resOne.await()
+    val manyToOneCall = greeter.greetClientStream()
+    manyToOneCall.send(req("Caroline"))
+    manyToOneCall.send(req("David"))
+    manyToOneCall.close()
+    val oneReply = manyToOneCall.await()
     println("single reply = ${oneReply.reply}")
 
     // === Bidirectional call =====================================================================
 
-    val (req, res) = greeter.greetBidirectional()
-    val l = GlobalScope.launch {
+    val bidiCall = greeter.greetBidirectional()
+    launch {
       var n = 0
-      for (greetReply in res) {
+      for (greetReply in bidiCall) {
         println("r$n = ${greetReply.reply}")
         n++
       }
@@ -218,16 +210,15 @@ fun main(args: Array<String>) {
     }
 
     delay(200)
-    req.send(req("Eve"))
+    bidiCall.send(req("Eve"))
 
     delay(200)
-    req.send(req("Fred"))
+    bidiCall.send(req("Fred"))
 
     delay(200)
-    req.send(req("Gina"))
+    bidiCall.send(req("Gina"))
 
-    req.close()
-    l.join()
+    bidiCall.close()
   }
 }
 ```
@@ -284,12 +275,12 @@ override fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>): De
 Using `send()` and `close()` on `SendChannel<T>`.
 
 ```kotlin
-val (requests: SendChannel<GreetRequest>, response: Deferred<GreetReply>) = stub.greetClientStream()
-requests.send( /* GreetRequest */ )
-requests.send( /* GreetRequest */ )
-requests.close() //  don't forget to close the send channel
+val call: ManyToOneCall<GreetRequest, GreetReply> = stub.greetClientStream()
+call.send( /* GreetRequest */ )
+call.send( /* GreetRequest */ )
+call.close() //  don't forget to close the send channel
 
-val responseMessage = response.await()
+val responseMessage = call.await()
 ```
 
 ### Unary request, Streaming response
@@ -301,7 +292,7 @@ val responseMessage = response.await()
 Using [`produce`] coroutine builder and `send` to return a stream of messages.
 
 ```kotlin
-override fun greetServerStream(request: GreetRequest): ReceiveChannel<GreetReply> = GlobalScope.produce {
+override fun greetServerStream(request: GreetRequest): ReceiveChannel<GreetReply> = produce {
   send( /* GreetReply message */ )
   send( /* GreetReply message */ )
   // ...
@@ -333,7 +324,7 @@ for (responseMessage in responses) {
 Using [`produce`] coroutine builder and `send` to return a stream of messages. Receiving messages from a `ReceiveChannel<T>`.
 
 ```kotlin
-override fun greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>): ReceiveChannel<GreetReply> = GlobalScope.produce {
+override fun greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>): ReceiveChannel<GreetReply> = produce {
   // receive request messages
   val firstRequest = requestChannel.receive()
   send( /* GreetReply message */ )
@@ -350,19 +341,17 @@ override fun greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>): R
 Using both a `SendChannel<T>` and a `ReceiveChannel<T>` to interact with the call.
 
 ```kotlin
-val (requests: SendChannel<GreetRequest>, responses: ReceiveChannel<GreetReply>) = stub.greetBidirectional()
-val responsePrinter = GlobalScope.launch {
-  for (responseMessage in responses) {
+val call: ManyToManyCall<GreetRequest, GreetReply> = stub.greetBidirectional()
+launch {
+  for (responseMessage in call) {
     log.info(responseMessage)
   }
   log.info("no more replies")
 }
 
-requests.send( /* GreetRequest */ )
-requests.send( /* GreetRequest */ )
-requests.close() //  don't forget to close the send channel
-
-responsePrinter.join() // wait for printer coroutine to finish
+call.send( /* GreetRequest */ )
+call.send( /* GreetRequest */ )
+call.close() //  don't forget to close the send channel
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
     coroutineContext = newFixedThreadPoolContext(4, "server-pool")
 ) {
 
-  override fun greet(request: GreetRequest) = async<GreetReply> {
-    GreetReply.newBuilder()
+  override suspend fun greet(request: GreetRequest): GreetReply {
+    return GreetReply.newBuilder()
         .setReply("Hello " + request.greeting)
         .build()
   }
@@ -131,14 +131,14 @@ class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
         .build())
   }
 
-  override fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>) = async<GreetReply> {
+  override suspend fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>): GreetReply {
     val greetings = mutableListOf<String>()
 
     for (request in requestChannel) {
       greetings.add(request.greeting)
     }
 
-    GreetReply.newBuilder()
+    return GreetReply.newBuilder()
         .setReply("Hi to all of $greetings!")
         .build()
   }
@@ -178,7 +178,7 @@ fun main(args: Array<String>) {
   runBlocking {
     // === Unary call =============================================================================
 
-    val unaryResponse = greeter.greet(req("Alice")).await()
+    val unaryResponse = greeter.greet(req("Alice"))
     println("unary reply = ${unaryResponse.reply}")
 
     // === Server streaming call ==================================================================
@@ -231,21 +231,20 @@ fun main(args: Array<String>) {
 
 #### Service
 
-Using [`async`] coroutine builder to return a single message.
+A suspendable function which returns a single message.
 
 ```kotlin
-override fun greet(request: GreetRequest): Deferred<GreetReply> = async {
+override suspend fun greet(request: GreetRequest): GreetReply {
   // return GreetReply message
 }
 ```
 
 #### Client
 
-Using `await()` on `Deferred<T>`.
+Suspendable call returning a single message.
 
 ```kotlin
-val response: Deferred<GreetReply> = stub.greet( /* GreetRequest */ )
-val responseMessage = response.await()
+val response: GreetReply = stub.greet( /* GreetRequest */ )
 ```
 
 ### Streaming request, Unary response
@@ -254,10 +253,10 @@ val responseMessage = response.await()
 
 #### Service
 
-Using [`async`] coroutine builder to return a single message, and receiving messages from a `ReceiveChannel<T>`.
+A suspendable function which returns a single message, and receives messages from a `ReceiveChannel<T>`.
 
 ```kotlin
-override fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>): Deferred<GreetReply> = async {
+override suspend fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>): GreetReply {
   // receive request messages
   val firstRequest = requestChannel.receive()
   

--- a/grpc-kotlin-gen/src/main/resources/KtStub.mustache
+++ b/grpc-kotlin-gen/src/main/resources/KtStub.mustache
@@ -26,7 +26,9 @@ import kotlinx.coroutines.experimental.channels.ReceiveChannel
 import kotlinx.coroutines.experimental.channels.SendChannel
 import kotlinx.coroutines.experimental.channels.consumeEach
 import kotlinx.coroutines.experimental.launch
+import kotlin.coroutines.experimental.Continuation
 import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.experimental.suspendCoroutine
 
 {{#deprecated}}@Deprecated("deprecated"){{/deprecated}}
 @javax.annotation.Generated(
@@ -65,10 +67,10 @@ object {{className}} {
         {{^isManyInput}}
         {{^isManyOutput}}
         {{! == unary req, unary resp == }}
-        fun {{methodName}}(request: {{inputType}}): Deferred<{{outputType}}> {
-            val responseDeferred = StreamObserverDeferred<{{outputType}}>()
-            delegate.{{methodName}}(request, responseDeferred)
-            return responseDeferred
+        suspend fun {{methodName}}(request: {{inputType}}): {{outputType}} {
+            return suspendCoroutine { cont ->
+                delegate.{{methodName}}(request, ContinuationStreamObserver(cont))
+            }
         }
         {{/isManyOutput}}
         {{#isManyOutput}}
@@ -112,7 +114,7 @@ object {{className}} {
         {{^isManyInput}}
         {{^isManyOutput}}
         {{! == unary req, unary resp == }}
-        open fun {{methodName}}(request: {{inputType}}): Deferred<{{outputType}}> {
+        open suspend fun {{methodName}}(request: {{inputType}}): {{outputType}} {
             throw unimplemented(get{{methodNamePascalCase}}Method()).asRuntimeException()
         }
 
@@ -123,7 +125,7 @@ object {{className}} {
             launch {
                 tryCatchingStatus(responseObserver) {
                     val response = {{methodName}}(request)
-                    onNext(response.await())
+                    onNext(response)
                 }
             }
         }
@@ -150,7 +152,7 @@ object {{className}} {
         {{#isManyInput}}
         {{^isManyOutput}}
         {{! == streaming req, unary resp == }}
-        open fun {{methodName}}(requestChannel: ReceiveChannel<{{inputType}}>): Deferred<{{outputType}}> {
+        open suspend fun {{methodName}}(requestChannel: ReceiveChannel<{{inputType}}>): {{outputType}} {
             throw unimplemented(get{{methodNamePascalCase}}Method()).asRuntimeException()
         }
 
@@ -161,7 +163,7 @@ object {{className}} {
             launch {
                 tryCatchingStatus(responseObserver) {
                     val response = {{methodName}}(requestChannel)
-                    onNext(response.await())
+                    onNext(response)
                 }
             }
             return requestChannel
@@ -260,6 +262,14 @@ object {{className}} {
         fun send(element: E) {
             streamObserver.onNext(element)
         }
+    }
+
+    private class ContinuationStreamObserver<E>(
+        private val continuation: Continuation<E>
+    ) : StreamObserver<E> {
+        override fun onNext(value: E) { continuation.resume(value) }
+        override fun onError(t: Throwable) { continuation.resumeWithException(t) }
+        override fun onCompleted() { }
     }
 
     private class StreamObserverDeferred<E>(

--- a/grpc-kotlin-gen/src/main/resources/KtStub.mustache
+++ b/grpc-kotlin-gen/src/main/resources/KtStub.mustache
@@ -1,5 +1,5 @@
 {{#packageName}}
-package {{packageName}};
+package {{packageName}}
 {{/packageName}}
 
 import {{packageName}}.{{serviceName}}Grpc.*
@@ -7,18 +7,25 @@ import {{packageName}}.{{serviceName}}Grpc.*
 import io.grpc.BindableService
 import io.grpc.CallOptions
 import io.grpc.Channel
+import io.grpc.MethodDescriptor
 import io.grpc.ServerServiceDefinition
+import io.grpc.Status
+import io.grpc.StatusException
+import io.grpc.StatusRuntimeException
 import io.grpc.stub.AbstractStub
 import io.grpc.stub.ServerCalls
 import io.grpc.stub.StreamObserver
 
 import kotlinx.coroutines.experimental.CompletableDeferred
+import kotlinx.coroutines.experimental.CoroutineScope
 import kotlinx.coroutines.experimental.Deferred
+import kotlinx.coroutines.experimental.Dispatchers
 import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.channels.Channel as KtChannel
 import kotlinx.coroutines.experimental.channels.ReceiveChannel
 import kotlinx.coroutines.experimental.channels.SendChannel
 import kotlinx.coroutines.experimental.launch
+import kotlin.coroutines.experimental.CoroutineContext
 
 {{#deprecated}}@Deprecated("deprecated"){{/deprecated}}
 @javax.annotation.Generated(
@@ -98,7 +105,9 @@ object {{className}} {
     }
 
     {{#javaDoc}}{{{javaDoc}}}{{/javaDoc}}
-    abstract class {{serviceName}}ImplBase : BindableService {
+    abstract class {{serviceName}}ImplBase(
+        override val coroutineContext: CoroutineContext = Dispatchers.Default
+    ) : BindableService, CoroutineScope {
 
         {{#methods}}
         {{#javaDoc}}{{{javaDoc}}}{{/javaDoc}}
@@ -114,8 +123,13 @@ object {{className}} {
             request: {{inputType}},
             responseObserver: StreamObserver<{{outputType}}>
         ) {
-            val responseDeferred = {{methodName}}(request)
-            connectDeferredToObserver(responseDeferred, responseObserver)
+            launch {
+                tryCatchingStatus(responseObserver) {
+                    val response = {{methodName}}(request)
+                    responseObserver.onNext(response.await())
+                    responseObserver.onCompleted()
+                }
+            }
         }
         {{/isManyOutput}}
         {{#isManyOutput}}
@@ -128,8 +142,14 @@ object {{className}} {
             request: {{inputType}},
             responseObserver: StreamObserver<{{outputType}}>
         ) {
-            val responseChannel = {{methodName}}(request)
-            connectChannelToObserver(responseChannel, responseObserver)
+            launch {
+                tryCatchingStatus(responseObserver) {
+                    for (value in {{methodName}}(request)) {
+                        responseObserver.onNext(value)
+                    }
+                    responseObserver.onCompleted()
+                }
+            }
         }
         {{/isManyOutput}}
         {{/isManyInput}}
@@ -144,8 +164,13 @@ object {{className}} {
             responseObserver: StreamObserver<{{outputType}}>
         ): StreamObserver<{{inputType}}> {
             val requestChannel = StreamObserverChannel<{{inputType}}>()
-            val responseDeferred = {{methodName}}(requestChannel)
-            connectDeferredToObserver(responseDeferred, responseObserver)
+            launch {
+                tryCatchingStatus(responseObserver) {
+                    val response = {{methodName}}(requestChannel)
+                    responseObserver.onNext(response.await())
+                    responseObserver.onCompleted()
+                }
+            }
             return requestChannel
         }
         {{/isManyOutput}}
@@ -159,8 +184,14 @@ object {{className}} {
             responseObserver: StreamObserver<{{outputType}}>
         ): StreamObserver<{{inputType}}> {
             val requestChannel = StreamObserverChannel<{{inputType}}>()
-            val responseChannel = {{methodName}}(requestChannel)
-            connectChannelToObserver(responseChannel, responseObserver)
+            launch {
+                tryCatchingStatus(responseObserver) {
+                    for (value in {{methodName}}(requestChannel)) {
+                        responseObserver.onNext(value)
+                    }
+                    responseObserver.onCompleted()
+                }
+            }
             return requestChannel
         }
         {{/isManyOutput}}
@@ -178,6 +209,25 @@ object {{className}} {
                 )
                 {{/methods}}
                 .build()
+        }
+    }
+
+    private suspend fun tryCatchingStatus(responseObserver: StreamObserver<*>, body: suspend () -> Unit) {
+        try {
+            body()
+        } catch (t: StatusException) {
+            responseObserver.onError(t)
+        } catch (t: StatusRuntimeException) {
+            responseObserver.onError(t)
+        } catch (t: RuntimeException) {
+            responseObserver.onError(Status.UNKNOWN.asRuntimeException())
+            throw t
+        } catch (t: Exception) {
+            responseObserver.onError(Status.UNKNOWN.asException())
+            throw t
+        } catch (t: Throwable) {
+            responseObserver.onError(Status.INTERNAL.asException())
+            throw t
         }
     }
 
@@ -226,7 +276,7 @@ object {{className}} {
     }
 
     private class StreamObserverChannel<E>
-        : KtChannel<E> by KtChannel<E>(KtChannel.UNLIMITED), StreamObserver<E> {
+        : StreamObserver<E>, KtChannel<E> by KtChannel<E>(KtChannel.UNLIMITED) {
 
         override fun onNext(value: E) { offer(value) }
         override fun onError(t: Throwable?) { close(cause = t) }

--- a/grpc-kotlin-gen/src/main/resources/KtStub.mustache
+++ b/grpc-kotlin-gen/src/main/resources/KtStub.mustache
@@ -116,7 +116,7 @@ object {{className}} {
         {{^isManyOutput}}
         {{! == unary req, unary resp == }}
         open fun {{methodName}}(request: {{inputType}}): Deferred<{{outputType}}> {
-            throw io.grpc.StatusRuntimeException(io.grpc.Status.UNIMPLEMENTED)
+            throw unimplemented(get{{methodNamePascalCase}}Method()).asRuntimeException()
         }
 
         internal fun {{methodName}}Internal(
@@ -135,7 +135,7 @@ object {{className}} {
         {{#isManyOutput}}
         {{! == unary req, streaming resp == }}
         open fun {{methodName}}(request: {{inputType}}): ReceiveChannel<{{outputType}}> {
-            throw io.grpc.StatusRuntimeException(io.grpc.Status.UNIMPLEMENTED)
+            throw unimplemented(get{{methodNamePascalCase}}Method()).asRuntimeException()
         }
 
         internal fun {{methodName}}Internal(
@@ -157,7 +157,7 @@ object {{className}} {
         {{^isManyOutput}}
         {{! == streaming req, unary resp == }}
         open fun {{methodName}}(requestChannel: ReceiveChannel<{{inputType}}>): Deferred<{{outputType}}> {
-            throw io.grpc.StatusRuntimeException(io.grpc.Status.UNIMPLEMENTED)
+            throw unimplemented(get{{methodNamePascalCase}}Method()).asRuntimeException()
         }
 
         internal fun {{methodName}}Internal(
@@ -177,7 +177,7 @@ object {{className}} {
         {{#isManyOutput}}
         {{! == streaming req, streaming resp == }}
         open fun {{methodName}}(requestChannel: ReceiveChannel<{{inputType}}>): ReceiveChannel<{{outputType}}> {
-            throw io.grpc.StatusRuntimeException(io.grpc.Status.UNIMPLEMENTED)
+            throw unimplemented(get{{methodNamePascalCase}}Method()).asRuntimeException()
         }
 
         internal fun {{methodName}}Internal(
@@ -210,6 +210,16 @@ object {{className}} {
                 {{/methods}}
                 .build()
         }
+    }
+
+    private fun unimplemented(methodDescriptor: MethodDescriptor<*, *>): Status {
+        return Status.UNIMPLEMENTED
+            .withDescription(
+                String.format(
+                    "Method %s is unimplemented",
+                    methodDescriptor.fullMethodName
+                )
+            )
     }
 
     private suspend fun tryCatchingStatus(responseObserver: StreamObserver<*>, body: suspend () -> Unit) {

--- a/grpc-kotlin-gen/src/main/resources/KtStub.mustache
+++ b/grpc-kotlin-gen/src/main/resources/KtStub.mustache
@@ -267,15 +267,17 @@ object {{className}} {
         }
     }
 
-    data class ManyToOneCall<in TRequest, out TResponse>(
-        val request: SendChannel<TRequest>,
-        val response: Deferred<TResponse>
-    )
+    class ManyToOneCall<in TRequest, out TResponse>(
+        private val request: SendChannel<TRequest>,
+        private val response: Deferred<TResponse>
+    ) : SendChannel<TRequest> by request,
+        Deferred<TResponse> by response
 
-    data class ManyToManyCall<in TRequest, out TResponse>(
-        val request: SendChannel<TRequest>,
-        val response: ReceiveChannel<TResponse>
-    )
+    class ManyToManyCall<in TRequest, out TResponse>(
+        private val request: SendChannel<TRequest>,
+        private val response: ReceiveChannel<TResponse>
+    ) : SendChannel<TRequest> by request,
+        ReceiveChannel<TResponse> by response
 
     private class StreamObserverDeferred<E>
         : StreamObserver<E>, CompletableDeferred<E> by CompletableDeferred() {

--- a/grpc-kotlin-gen/src/main/resources/KtStub.mustache
+++ b/grpc-kotlin-gen/src/main/resources/KtStub.mustache
@@ -24,6 +24,7 @@ import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.channels.Channel as KtChannel
 import kotlinx.coroutines.experimental.channels.ReceiveChannel
 import kotlinx.coroutines.experimental.channels.SendChannel
+import kotlinx.coroutines.experimental.channels.consumeEach
 import kotlinx.coroutines.experimental.launch
 import kotlin.coroutines.experimental.CoroutineContext
 
@@ -85,9 +86,7 @@ object {{className}} {
         fun {{methodName}}(): ManyToOneCall<{{inputType}}, {{outputType}}> {
             val responseDeferred = StreamObserverDeferred<{{outputType}}>()
             val requestObserver = delegate.{{methodName}}(responseDeferred)
-            val requestChannel = KtChannel<{{inputType}}>(KtChannel.UNLIMITED)
-            connectChannelToObserver(requestChannel, requestObserver)
-            return ManyToOneCall(requestChannel, responseDeferred)
+            return ManyToOneCall(requestObserver, responseDeferred)
         }
         {{/isManyOutput}}
         {{#isManyOutput}}
@@ -95,9 +94,7 @@ object {{className}} {
         fun {{methodName}}(): ManyToManyCall<{{inputType}}, {{outputType}}> {
             val responseChannel = StreamObserverChannel<{{outputType}}>()
             val requestObserver = delegate.{{methodName}}(responseChannel)
-            val requestChannel = KtChannel<{{inputType}}>(KtChannel.UNLIMITED)
-            connectChannelToObserver(requestChannel, requestObserver)
-            return ManyToManyCall(requestChannel, responseChannel)
+            return ManyToManyCall(requestObserver, responseChannel)
         }
         {{/isManyOutput}}
         {{/isManyInput}}
@@ -126,8 +123,7 @@ object {{className}} {
             launch {
                 tryCatchingStatus(responseObserver) {
                     val response = {{methodName}}(request)
-                    responseObserver.onNext(response.await())
-                    responseObserver.onCompleted()
+                    onNext(response.await())
                 }
             }
         }
@@ -144,10 +140,8 @@ object {{className}} {
         ) {
             launch {
                 tryCatchingStatus(responseObserver) {
-                    for (value in {{methodName}}(request)) {
-                        responseObserver.onNext(value)
-                    }
-                    responseObserver.onCompleted()
+                    {{methodName}}(request)
+                        .consumeEach { onNext(it) }
                 }
             }
         }
@@ -167,8 +161,7 @@ object {{className}} {
             launch {
                 tryCatchingStatus(responseObserver) {
                     val response = {{methodName}}(requestChannel)
-                    responseObserver.onNext(response.await())
-                    responseObserver.onCompleted()
+                    onNext(response.await())
                 }
             }
             return requestChannel
@@ -186,10 +179,8 @@ object {{className}} {
             val requestChannel = StreamObserverChannel<{{inputType}}>()
             launch {
                 tryCatchingStatus(responseObserver) {
-                    for (value in {{methodName}}(requestChannel)) {
-                        responseObserver.onNext(value)
-                    }
-                    responseObserver.onCompleted()
+                    {{methodName}}(requestChannel)
+                        .consumeEach { onNext(it) }
                 }
             }
             return requestChannel
@@ -222,9 +213,10 @@ object {{className}} {
             )
     }
 
-    private suspend fun tryCatchingStatus(responseObserver: StreamObserver<*>, body: suspend () -> Unit) {
+    private suspend fun <E> tryCatchingStatus(responseObserver: StreamObserver<E>, body: suspend StreamObserver<E>.() -> Unit) {
         try {
-            body()
+            responseObserver.body()
+            responseObserver.onCompleted()
         } catch (t: StatusException) {
             responseObserver.onError(t)
         } catch (t: StatusRuntimeException) {
@@ -241,58 +233,51 @@ object {{className}} {
         }
     }
 
-    private fun <E> connectChannelToObserver(channel: ReceiveChannel<E>, observer: StreamObserver<E>) {
-        // todo: specify coroutine context
-        GlobalScope.launch {
-            try {
-                for (value in channel) {
-                    observer.onNext(value)
-                }
-                observer.onCompleted()
-            } catch (t: Throwable) {
-                observer.onError(t)
-            }
-        }
-    }
-
-    private fun <E> connectDeferredToObserver(deferred: Deferred<E>, observer: StreamObserver<E>) {
-        // todo: specify coroutine context
-        GlobalScope.launch {
-            try {
-                observer.onNext(deferred.await())
-                observer.onCompleted()
-            } catch (t: Throwable) {
-                observer.onError(t)
-            }
-        }
-    }
-
     class ManyToOneCall<in TRequest, out TResponse>(
-        private val request: SendChannel<TRequest>,
+        private val request: StreamObserver<TRequest>,
         private val response: Deferred<TResponse>
-    ) : SendChannel<TRequest> by request,
+    ) : StreamObserverSendAdapter<TRequest>(request),
         Deferred<TResponse> by response
 
     class ManyToManyCall<in TRequest, out TResponse>(
-        private val request: SendChannel<TRequest>,
+        private val request: StreamObserver<TRequest>,
         private val response: ReceiveChannel<TResponse>
-    ) : SendChannel<TRequest> by request,
+    ) : StreamObserverSendAdapter<TRequest>(request),
         ReceiveChannel<TResponse> by response
 
-    private class StreamObserverDeferred<E>
-        : StreamObserver<E>, CompletableDeferred<E> by CompletableDeferred() {
+    open class StreamObserverSendAdapter<in E>(private val streamObserver: StreamObserver<E>) {
 
-        override fun onNext(value: E) { complete(value) }
-        override fun onError(t: Throwable) { cancel(t) }
+        fun close(cause: Throwable? = null): Boolean {
+            if (cause != null) {
+                streamObserver.onError(cause)
+            } else {
+                streamObserver.onCompleted()
+            }
+
+            return true
+        }
+
+        fun send(element: E) {
+            streamObserver.onNext(element)
+        }
+    }
+
+    private class StreamObserverDeferred<E>(
+        private val deferred: CompletableDeferred<E> = CompletableDeferred()
+    ) : StreamObserver<E>, Deferred<E> by deferred {
+
+        override fun onNext(value: E) { deferred.complete(value) }
+        override fun onError(t: Throwable) { deferred.cancel(t) }
         override fun onCompleted() { /* nothing */ }
     }
 
-    private class StreamObserverChannel<E>
-        : StreamObserver<E>, KtChannel<E> by KtChannel<E>(KtChannel.UNLIMITED) {
+    private class StreamObserverChannel<E>(
+        private val channel: KtChannel<E> = KtChannel<E>(KtChannel.UNLIMITED)
+    ) : StreamObserver<E>, ReceiveChannel<E> by channel {
 
-        override fun onNext(value: E) { offer(value) }
-        override fun onError(t: Throwable?) { close(cause = t) }
-        override fun onCompleted() { close(cause = null) }
+        override fun onNext(value: E) { channel.offer(value) }
+        override fun onError(t: Throwable?) { channel.close(cause = t) }
+        override fun onCompleted() { channel.close(cause = null) }
     }
 
     {{#methods}}

--- a/grpc-kotlin-test/pom.xml
+++ b/grpc-kotlin-test/pom.xml
@@ -59,6 +59,18 @@
     </dependency>
 
     <!-- scope : test -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-testing</artifactId>
+      <version>${grpc.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
+++ b/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
@@ -47,6 +47,7 @@ class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
 
     override fun greetServerStream(request: GreetRequest) = produce<GreetReply> {
         log.info(request.greeting)
+
         send(
             GreetReply.newBuilder()
                 .setReply("Hello ${request.greeting}!")

--- a/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
+++ b/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
@@ -20,7 +20,6 @@
 
 package io.rouz.greeter
 
-import kotlinx.coroutines.experimental.async
 import kotlinx.coroutines.experimental.channels.ReceiveChannel
 import kotlinx.coroutines.experimental.channels.produce
 import kotlinx.coroutines.experimental.delay
@@ -37,10 +36,10 @@ class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
 
     private val log = KotlinLogging.logger("server")
 
-    override fun greet(request: GreetRequest) = async<GreetReply> {
+    override suspend fun greet(request: GreetRequest): GreetReply {
         log.info(request.greeting)
 
-        GreetReply.newBuilder()
+        return GreetReply.newBuilder()
             .setReply("Hello " + request.greeting)
             .build()
     }
@@ -60,7 +59,7 @@ class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
         )
     }
 
-    override fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>) = async<GreetReply> {
+    override suspend fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>): GreetReply {
         val greetings = mutableListOf<String>()
 
         for (request in requestChannel) {
@@ -68,7 +67,7 @@ class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
             greetings.add(request.greeting)
         }
 
-        GreetReply.newBuilder()
+        return GreetReply.newBuilder()
             .setReply("Hi to all of $greetings!")
             .build()
     }

--- a/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
+++ b/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
@@ -20,7 +20,6 @@
 
 package io.rouz.greeter
 
-import kotlinx.coroutines.experimental.Job
 import kotlinx.coroutines.experimental.async
 import kotlinx.coroutines.experimental.channels.ReceiveChannel
 import kotlinx.coroutines.experimental.channels.produce
@@ -75,12 +74,11 @@ class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
 
     override fun greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) = produce<GreetReply> {
         var count = 0
-        val queue = mutableListOf<Job>()
 
         for (request in requestChannel) {
             val n = count++
             log.info("$n ${request.greeting}")
-            val job = launch {
+            launch {
                 delay(1000)
                 send(
                     GreetReply.newBuilder()
@@ -89,11 +87,7 @@ class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
                 )
                 log.info("dispatched $n")
             }
-            queue.add(job)
         }
-
-        log.info("waiting for jobs")
-        queue.forEach { it.join() }
 
         log.info("completing")
     }

--- a/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterMain.kt
+++ b/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterMain.kt
@@ -42,7 +42,7 @@ fun main(args: Array<String>) {
     runBlocking {
         // === Unary call =============================================================================
 
-        val unaryResponse = greeter.greet(req("Alice")).await()
+        val unaryResponse = greeter.greet(req("Alice"))
         log.info("unary reply = ${unaryResponse.reply}")
 
         // === Server streaming call ==================================================================

--- a/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterMain.kt
+++ b/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterMain.kt
@@ -64,10 +64,10 @@ fun main(args: Array<String>) {
         // === Bidirectional call =====================================================================
 
         val bidiCall = greeter.greetBidirectional()
-        val l = launch {
+        launch {
             var n = 0
             for (greetReply in bidiCall) {
-                log.info("r$n = ${greetReply.reply}")
+                log.info("reply $n = ${greetReply.reply}")
                 n++
             }
             log.info("no more replies")
@@ -81,9 +81,7 @@ fun main(args: Array<String>) {
 
         delay(200)
         bidiCall.send(req("Gina"))
-
         bidiCall.close()
-        l.join()
     }
 }
 

--- a/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterMain.kt
+++ b/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterMain.kt
@@ -54,19 +54,19 @@ fun main(args: Array<String>) {
 
         // === Client streaming call ==================================================================
 
-        val (reqMany, resOne) = greeter.greetClientStream()
-        reqMany.send(req("Caroline"))
-        reqMany.send(req("David"))
-        reqMany.close()
-        val oneReply = resOne.await()
+        val manyToOneCall = greeter.greetClientStream()
+        manyToOneCall.send(req("Caroline"))
+        manyToOneCall.send(req("David"))
+        manyToOneCall.close()
+        val oneReply = manyToOneCall.await()
         log.info("single reply = ${oneReply.reply}")
 
         // === Bidirectional call =====================================================================
 
-        val (req, res) = greeter.greetBidirectional()
+        val bidiCall = greeter.greetBidirectional()
         val l = launch {
             var n = 0
-            for (greetReply in res) {
+            for (greetReply in bidiCall) {
                 log.info("r$n = ${greetReply.reply}")
                 n++
             }
@@ -74,15 +74,15 @@ fun main(args: Array<String>) {
         }
 
         delay(200)
-        req.send(req("Eve"))
+        bidiCall.send(req("Eve"))
 
         delay(200)
-        req.send(req("Fred"))
+        bidiCall.send(req("Fred"))
 
         delay(200)
-        req.send(req("Gina"))
+        bidiCall.send(req("Gina"))
 
-        req.close()
+        bidiCall.close()
         l.join()
     }
 }

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ExceptionPropagationTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ExceptionPropagationTest.kt
@@ -1,0 +1,188 @@
+/*-
+ * -\-\-
+ * grpc-kotlin-test
+ * --
+ * Copyright (C) 2016 - 2018 rouz.io
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package io.rouz.greeter
+
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import kotlinx.coroutines.experimental.CoroutineExceptionHandler
+import kotlinx.coroutines.experimental.Dispatchers
+import kotlinx.coroutines.experimental.async
+import kotlinx.coroutines.experimental.channels.ReceiveChannel
+import kotlinx.coroutines.experimental.channels.produce
+import kotlinx.coroutines.experimental.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class ExceptionPropagationTest : GrpcTestBase() {
+
+    @Rule
+    @JvmField
+    val expect = ExpectedException.none()
+
+    @Test
+    fun unaryStatus() {
+        val stub = startServer(StatusThrowingGreeter())
+
+        expect.expect(StatusRuntimeException::class.java)
+        expect.expectMessage("NOT_FOUND: neh")
+
+        runBlocking {
+            stub.greet(req("joe")).await()
+        }
+    }
+
+    @Test
+    fun serverStreamingStatus() {
+        val stub = startServer(StatusThrowingGreeter())
+
+        expect.expect(StatusRuntimeException::class.java)
+        expect.expectMessage("NOT_FOUND: neh")
+
+        runBlocking {
+            stub.greetServerStream(req("joe")).receive()
+        }
+    }
+
+    @Test
+    fun clientStreamingStatus() {
+        val stub = startServer(StatusThrowingGreeter())
+
+        expect.expect(StatusRuntimeException::class.java)
+        expect.expectMessage("NOT_FOUND: neh")
+
+        runBlocking {
+            stub.greetClientStream().await()
+        }
+    }
+
+    @Test
+    fun bidirectionalStatus() {
+        val stub = startServer(StatusThrowingGreeter())
+
+        expect.expect(StatusRuntimeException::class.java)
+        expect.expectMessage("NOT_FOUND: neh")
+
+        runBlocking {
+            stub.greetBidirectional().receive()
+        }
+    }
+
+    @Test
+    fun unaryException() {
+        val stub = startServer(GenericThrowingGreeter())
+
+        expect.expect(StatusRuntimeException::class.java)
+        expect.expectMessage("UNKNOWN")
+
+        runBlocking {
+            stub.greet(req("joe")).await()
+        }
+    }
+
+    @Test
+    fun serverStreamingException() {
+        val stub = startServer(GenericThrowingGreeter())
+
+        expect.expect(StatusRuntimeException::class.java)
+        expect.expectMessage("UNKNOWN")
+
+        runBlocking {
+            stub.greetServerStream(req("joe")).receive()
+        }
+    }
+
+    @Test
+    fun clientStreamingException() {
+        val stub = startServer(GenericThrowingGreeter())
+
+        expect.expect(StatusRuntimeException::class.java)
+        expect.expectMessage("UNKNOWN")
+
+        runBlocking {
+            stub.greetClientStream().await()
+        }
+    }
+
+    @Test
+    fun bidirectionalException() {
+        val stub = startServer(GenericThrowingGreeter())
+
+        expect.expect(StatusRuntimeException::class.java)
+        expect.expectMessage("UNKNOWN")
+
+        runBlocking {
+            stub.greetBidirectional().receive()
+        }
+    }
+
+    private class StatusThrowingGreeter : GreeterGrpcKt.GreeterImplBase() {
+
+        override fun greet(request: GreetRequest) = async<GreetReply> {
+            throw notFound()
+        }
+
+        override fun greetServerStream(request: GreetRequest) = produce<GreetReply> {
+            throw notFound()
+        }
+
+        override fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>) = async<GreetReply> {
+            throw notFound()
+        }
+
+        override fun greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) = produce<GreetReply> {
+            throw notFound()
+        }
+
+        private fun notFound(): StatusRuntimeException {
+            return Status.NOT_FOUND.withDescription("neh").asRuntimeException()
+        }
+    }
+
+    private class GenericThrowingGreeter : GreeterGrpcKt.GreeterImplBase(
+        Dispatchers.Default + CoroutineExceptionHandler { _, _ -> /* shh */ }
+    ) {
+
+        override fun greet(request: GreetRequest) = async<GreetReply> {
+            throw broke()
+        }
+
+        override fun greetServerStream(request: GreetRequest) = produce<GreetReply> {
+            throw broke()
+        }
+
+        override fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>) = async<GreetReply> {
+            throw broke()
+        }
+
+        override fun greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) = produce<GreetReply> {
+            throw broke()
+        }
+
+        private fun broke(): Exception {
+            return Exception("my app broke")
+        }
+    }
+
+}

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ExceptionPropagationTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ExceptionPropagationTest.kt
@@ -24,7 +24,6 @@ import io.grpc.Status
 import io.grpc.StatusRuntimeException
 import kotlinx.coroutines.experimental.CoroutineExceptionHandler
 import kotlinx.coroutines.experimental.Dispatchers
-import kotlinx.coroutines.experimental.async
 import kotlinx.coroutines.experimental.channels.ReceiveChannel
 import kotlinx.coroutines.experimental.channels.produce
 import kotlinx.coroutines.experimental.runBlocking
@@ -49,7 +48,7 @@ class ExceptionPropagationTest : GrpcTestBase() {
         expect.expectMessage("NOT_FOUND: neh")
 
         runBlocking {
-            stub.greet(req("joe")).await()
+            stub.greet(req("joe"))
         }
     }
 
@@ -97,7 +96,7 @@ class ExceptionPropagationTest : GrpcTestBase() {
         expect.expectMessage("UNKNOWN")
 
         runBlocking {
-            stub.greet(req("joe")).await()
+            stub.greet(req("joe"))
         }
     }
 
@@ -139,7 +138,7 @@ class ExceptionPropagationTest : GrpcTestBase() {
 
     private class StatusThrowingGreeter : GreeterGrpcKt.GreeterImplBase() {
 
-        override fun greet(request: GreetRequest) = async<GreetReply> {
+        override suspend fun greet(request: GreetRequest): GreetReply {
             throw notFound()
         }
 
@@ -147,7 +146,7 @@ class ExceptionPropagationTest : GrpcTestBase() {
             throw notFound()
         }
 
-        override fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>) = async<GreetReply> {
+        override suspend fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>): GreetReply {
             throw notFound()
         }
 
@@ -164,7 +163,7 @@ class ExceptionPropagationTest : GrpcTestBase() {
         Dispatchers.Default + CoroutineExceptionHandler { _, _ -> /* shh */ }
     ) {
 
-        override fun greet(request: GreetRequest) = async<GreetReply> {
+        override suspend fun greet(request: GreetRequest): GreetReply {
             throw broke()
         }
 
@@ -172,7 +171,7 @@ class ExceptionPropagationTest : GrpcTestBase() {
             throw broke()
         }
 
-        override fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>) = async<GreetReply> {
+        override suspend fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>): GreetReply {
             throw broke()
         }
 

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/GrpcTestBase.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/GrpcTestBase.kt
@@ -1,0 +1,59 @@
+/*-
+ * -\-\-
+ * grpc-kotlin-test
+ * --
+ * Copyright (C) 2016 - 2018 rouz.io
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package io.rouz.greeter
+
+import io.grpc.inprocess.InProcessChannelBuilder
+import io.grpc.inprocess.InProcessServerBuilder
+import io.grpc.testing.GrpcCleanupRule
+import io.rouz.greeter.GreeterGrpcKt.GreeterImplBase
+import io.rouz.greeter.GreeterGrpcKt.GreeterKtStub
+import org.junit.Rule
+
+open class GrpcTestBase {
+
+    @Rule
+    @JvmField
+    val grpcCleanup = GrpcCleanupRule()
+
+    private val serverName = InProcessServerBuilder.generateName()
+
+    protected fun startServer(service: GreeterImplBase): GreeterKtStub {
+        grpcCleanup.register(
+            InProcessServerBuilder.forName(serverName)
+                .directExecutor()
+                .addService(service)
+                .build()
+                .start()
+        )
+
+        val channel = grpcCleanup.register(
+            InProcessChannelBuilder.forName(serverName)
+                .directExecutor()
+                .build()
+        )
+
+        return GreeterGrpcKt.newStub(channel)
+    }
+
+    fun req(greeting: String): GreetRequest {
+        return GreetRequest.newBuilder().setGreeting(greeting).build()
+    }
+}

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ServiceCallsTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ServiceCallsTest.kt
@@ -34,7 +34,7 @@ class ServiceCallsTest : GrpcTestBase() {
         val stub = startServer(GreeterImpl())
 
         runBlocking {
-            val reply = stub.greet(req("rouz")).await()
+            val reply = stub.greet(req("rouz"))
 
             assertEquals("Hello rouz", reply.reply)
         }

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ServiceCallsTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ServiceCallsTest.kt
@@ -1,0 +1,90 @@
+/*-
+ * -\-\-
+ * grpc-kotlin-test
+ * --
+ * Copyright (C) 2016 - 2018 rouz.io
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package io.rouz.greeter
+
+import kotlinx.coroutines.experimental.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class ServiceCallsTest : GrpcTestBase() {
+
+    @Test
+    fun unaryGreet() {
+        val stub = startServer(GreeterImpl())
+
+        runBlocking {
+            val reply = stub.greet(req("rouz")).await()
+
+            assertEquals("Hello rouz", reply.reply)
+        }
+    }
+
+    @Test
+    fun serverStreamingGreet() {
+        val stub = startServer(GreeterImpl())
+
+        runBlocking {
+            val replies = stub.greetServerStream(req("rouz"))
+
+            assertEquals("Hello rouz!", replies.receive().reply)
+            assertEquals("Greetings rouz!", replies.receive().reply)
+        }
+    }
+
+    @Test
+    fun clientStreamingGreet() {
+        val stub = startServer(GreeterImpl())
+
+        runBlocking {
+            val call = stub.greetClientStream()
+
+            call.send(req("rouz"))
+            call.send(req("delavari"))
+            call.close()
+
+            val reply = call.await()
+
+            assertEquals("Hi to all of [rouz, delavari]!", reply.reply)
+        }
+    }
+
+    @Test
+    fun bidirectionalGreet() {
+        val stub = startServer(GreeterImpl())
+
+        runBlocking {
+            val call = stub.greetBidirectional()
+
+            call.send(req("rouz"))
+            val reply1 = call.receive()
+            assertEquals("Yo #0 rouz", reply1.reply)
+
+            call.send(req("delavari"))
+            val reply2 = call.receive()
+            assertEquals("Yo #1 delavari", reply2.reply)
+
+            call.close()
+        }
+    }
+}


### PR DESCRIPTION
This should also remedy #3 by allowing a [`CoroutineExceptionHandler`](https://kotlinlang.org/docs/reference/coroutines/exception-handling.html#coroutineexceptionhandler) to be added to the `CoroutineContext`, like:

```kotlin
val handler = CoroutineExceptionHandler { _, exception ->
    println("Caught $exception")
}

class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
    coroutineContext = Dispatchers.Default + handler
) {
    override fun greet(request: GreetRequest) = async<GreetReply> {
        throw SomeApplicationSpecificException("oops!")
    }
}
```