### PR TITLE
Make server streaming functions suspending

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
         .build()
   }
 
-  override fun greetServerStream(request: GreetRequest) = produce<GreetReply> {
+  override suspend fun greetServerStream(request: GreetRequest) = produce<GreetReply> {
     send(GreetReply.newBuilder()
         .setReply("Hello ${request.greeting}!")
         .build())
@@ -142,7 +142,7 @@ class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
         .build()
   }
 
-  override fun greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) = produce<GreetReply> {
+  override suspend fun greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) = produce<GreetReply> {
     var count = 0
 
     for (request in requestChannel) {
@@ -291,7 +291,7 @@ val responseMessage = call.await()
 Using [`produce`] coroutine builder and `send` to return a stream of messages.
 
 ```kotlin
-override fun greetServerStream(request: GreetRequest): ReceiveChannel<GreetReply> = produce {
+override suspend fun greetServerStream(request: GreetRequest): ReceiveChannel<GreetReply> = produce {
   send( /* GreetReply message */ )
   send( /* GreetReply message */ )
   // ...
@@ -323,7 +323,7 @@ for (responseMessage in responses) {
 Using [`produce`] coroutine builder and `send` to return a stream of messages. Receiving messages from a `ReceiveChannel<T>`.
 
 ```kotlin
-override fun greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>): ReceiveChannel<GreetReply> = produce {
+override suspend fun greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>): ReceiveChannel<GreetReply> = produce {
   // receive request messages
   val firstRequest = requestChannel.receive()
   send( /* GreetReply message */ )

--- a/grpc-kotlin-gen/src/main/resources/KtStub.mustache
+++ b/grpc-kotlin-gen/src/main/resources/KtStub.mustache
@@ -132,7 +132,7 @@ object {{className}} {
         {{/isManyOutput}}
         {{#isManyOutput}}
         {{! == unary req, streaming resp == }}
-        open fun {{methodName}}(request: {{inputType}}): ReceiveChannel<{{outputType}}> {
+        open suspend fun {{methodName}}(request: {{inputType}}): ReceiveChannel<{{outputType}}> {
             throw unimplemented(get{{methodNamePascalCase}}Method()).asRuntimeException()
         }
 
@@ -171,7 +171,7 @@ object {{className}} {
         {{/isManyOutput}}
         {{#isManyOutput}}
         {{! == streaming req, streaming resp == }}
-        open fun {{methodName}}(requestChannel: ReceiveChannel<{{inputType}}>): ReceiveChannel<{{outputType}}> {
+        open suspend fun {{methodName}}(requestChannel: ReceiveChannel<{{inputType}}>): ReceiveChannel<{{outputType}}> {
             throw unimplemented(get{{methodNamePascalCase}}Method()).asRuntimeException()
         }
 

--- a/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
+++ b/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
@@ -44,7 +44,7 @@ class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
             .build()
     }
 
-    override fun greetServerStream(request: GreetRequest) = produce<GreetReply> {
+    override suspend fun greetServerStream(request: GreetRequest) = produce<GreetReply> {
         log.info(request.greeting)
 
         send(
@@ -72,7 +72,7 @@ class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
             .build()
     }
 
-    override fun greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) = produce<GreetReply> {
+    override suspend fun greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) = produce<GreetReply> {
         var count = 0
 
         for (request in requestChannel) {

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ExceptionPropagationTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ExceptionPropagationTest.kt
@@ -142,7 +142,7 @@ class ExceptionPropagationTest : GrpcTestBase() {
             throw notFound()
         }
 
-        override fun greetServerStream(request: GreetRequest) = produce<GreetReply> {
+        override suspend fun greetServerStream(request: GreetRequest) = produce<GreetReply> {
             throw notFound()
         }
 
@@ -150,7 +150,7 @@ class ExceptionPropagationTest : GrpcTestBase() {
             throw notFound()
         }
 
-        override fun greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) = produce<GreetReply> {
+        override suspend fun greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) = produce<GreetReply> {
             throw notFound()
         }
 
@@ -167,7 +167,7 @@ class ExceptionPropagationTest : GrpcTestBase() {
             throw broke()
         }
 
-        override fun greetServerStream(request: GreetRequest) = produce<GreetReply> {
+        override suspend fun greetServerStream(request: GreetRequest) = produce<GreetReply> {
             throw broke()
         }
 
@@ -175,7 +175,7 @@ class ExceptionPropagationTest : GrpcTestBase() {
             throw broke()
         }
 
-        override fun greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) = produce<GreetReply> {
+        override suspend fun greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) = produce<GreetReply> {
             throw broke()
         }
 


### PR DESCRIPTION
Currently RPCs which return a single value are `suspend` functions, it probably makes sense to be consistent, making all service functions `suspend`. This also allows certain natural implementations other than using the `produce` function. In my case, my service function is calling to another `suspend` function which returns a `ReceiveChannel`, `map` is then used to transform the results from that channel into gRPC response objects.