### PR TITLE
Prevent unreachable code warning

### DIFF
--- a/grpc-kotlin-gen/src/main/resources/KtStub.mustache
+++ b/grpc-kotlin-gen/src/main/resources/KtStub.mustache
@@ -320,11 +320,11 @@ object {{className}} {
 
         @Suppress("UNCHECKED_CAST")
         override fun invoke(responseObserver: StreamObserver<Resp>): StreamObserver<Req> {
-            return when (methodId) {
+            when (methodId) {
                 {{#methods}}
                 {{#isManyInput}}
                 METHODID_{{methodNameUpperUnderscore}} ->
-                    serviceImpl.{{methodName}}Internal(
+                    return serviceImpl.{{methodName}}Internal(
                         responseObserver as StreamObserver<{{outputType}}>
                     ) as StreamObserver<Req>
                 {{/isManyInput}}


### PR DESCRIPTION
When a service has no client streaming RPCs, the relevant `invoke()` method produces an unreachable code warning. The generated method will look like this:
```kotlin
        @Suppress("UNCHECKED_CAST")
        override fun invoke(responseObserver: StreamObserver<Resp>): StreamObserver<Req> {
            return when (methodId) {
                else -> throw AssertionError()
            }
        }
```
Default compiler settings will report that the `return` statement is unreachable, causing a warning in the console output. This PR moves the return statement inside the when clause. When no client streaming RPCs exist, we end up with:
```kotlin
        @Suppress("UNCHECKED_CAST")
        override fun invoke(responseObserver: StreamObserver<Resp>): StreamObserver<Req> {
            when (methodId) {
                else -> throw AssertionError()
            }
        }
```
When client streaming RPCs do exist, we get something like this:
```kotin
        @Suppress("UNCHECKED_CAST")
        override fun invoke(responseObserver: StreamObserver<Resp>): StreamObserver<Req> {
            when (methodId) {
                METHODID_GREET_CLIENT_STREAM ->
                    return serviceImpl.greetClientStreamInternal(
                        responseObserver as StreamObserver<io.rouz.greeter.GreetReply>
                    ) as StreamObserver<Req>
                METHODID_GREET_BIDIRECTIONAL ->
                    return serviceImpl.greetBidirectionalInternal(
                        responseObserver as StreamObserver<io.rouz.greeter.GreetReply>
                    ) as StreamObserver<Req>
                else -> throw AssertionError()
            }
        }
```