### PR TITLE
Use ProducerScope for server streaming calls

### DIFF
--- a/grpc-kotlin-gen/src/main/resources/KtStub.mustache
+++ b/grpc-kotlin-gen/src/main/resources/KtStub.mustache
@@ -4,31 +4,13 @@ package {{packageName}}
 
 import {{packageName}}.{{serviceName}}Grpc.*
 
-import io.grpc.BindableService
-import io.grpc.CallOptions
-import io.grpc.Channel
-import io.grpc.MethodDescriptor
-import io.grpc.ServerServiceDefinition
-import io.grpc.Status
-import io.grpc.StatusException
-import io.grpc.StatusRuntimeException
-import io.grpc.stub.AbstractStub
-import io.grpc.stub.ServerCalls
-import io.grpc.stub.StreamObserver
+import io.grpc.*
+import io.grpc.stub.*
 
-import kotlinx.coroutines.experimental.CompletableDeferred
-import kotlinx.coroutines.experimental.CoroutineScope
-import kotlinx.coroutines.experimental.Deferred
-import kotlinx.coroutines.experimental.Dispatchers
-import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.channels.Channel as KtChannel
-import kotlinx.coroutines.experimental.channels.ReceiveChannel
-import kotlinx.coroutines.experimental.channels.SendChannel
-import kotlinx.coroutines.experimental.channels.consumeEach
-import kotlinx.coroutines.experimental.launch
-import kotlin.coroutines.experimental.Continuation
-import kotlin.coroutines.experimental.CoroutineContext
-import kotlin.coroutines.experimental.suspendCoroutine
+import kotlinx.coroutines.experimental.*
+import kotlinx.coroutines.experimental.channels.*
+import kotlin.coroutines.experimental.*
 
 {{#deprecated}}@Deprecated("deprecated"){{/deprecated}}
 @javax.annotation.Generated(
@@ -132,7 +114,7 @@ object {{className}} {
         {{/isManyOutput}}
         {{#isManyOutput}}
         {{! == unary req, streaming resp == }}
-        open suspend fun {{methodName}}(request: {{inputType}}): ReceiveChannel<{{outputType}}> {
+        open suspend fun ProducerScope<{{outputType}}>.{{methodName}}(request: {{inputType}}) {
             throw unimplemented(get{{methodNamePascalCase}}Method()).asRuntimeException()
         }
 
@@ -141,10 +123,11 @@ object {{className}} {
             responseObserver: StreamObserver<{{outputType}}>
         ) {
             launch {
-                tryCatchingStatus(responseObserver) {
-                    {{methodName}}(request)
-                        .consumeEach { onNext(it) }
-                }
+                produce {
+                    tryCatchingStatus(responseObserver) {
+                        {{methodName}}(request)
+                    }
+                }.consumeEach { responseObserver.onNext(it) }
             }
         }
         {{/isManyOutput}}
@@ -171,7 +154,7 @@ object {{className}} {
         {{/isManyOutput}}
         {{#isManyOutput}}
         {{! == streaming req, streaming resp == }}
-        open suspend fun {{methodName}}(requestChannel: ReceiveChannel<{{inputType}}>): ReceiveChannel<{{outputType}}> {
+        open suspend fun ProducerScope<{{outputType}}>.{{methodName}}(requestChannel: ReceiveChannel<{{inputType}}>) {
             throw unimplemented(get{{methodNamePascalCase}}Method()).asRuntimeException()
         }
 
@@ -180,10 +163,11 @@ object {{className}} {
         ): StreamObserver<{{inputType}}> {
             val requestChannel = StreamObserverChannel<{{inputType}}>()
             launch {
-                tryCatchingStatus(responseObserver) {
-                    {{methodName}}(requestChannel)
-                        .consumeEach { onNext(it) }
-                }
+                produce {
+                    tryCatchingStatus(responseObserver) {
+                        {{methodName}}(requestChannel)
+                    }
+                }.consumeEach { responseObserver.onNext(it) }
             }
             return requestChannel
         }
@@ -215,23 +199,32 @@ object {{className}} {
             )
     }
 
+    private fun <E> handleException(t: Throwable?, responseObserver: StreamObserver<E>) {
+        when (t) {
+            null -> Unit
+            //is CancellationException -> handleException(t.cause, responseObserver)
+            is StatusException, is StatusRuntimeException -> responseObserver.onError(t)
+            is RuntimeException -> {
+                responseObserver.onError(Status.UNKNOWN.asRuntimeException())
+                throw t
+            }
+            is Exception -> {
+                responseObserver.onError(Status.UNKNOWN.asException())
+                throw t
+            }
+            else -> {
+                responseObserver.onError(Status.INTERNAL.asException())
+                throw t
+            }
+        }
+    }
+
     private suspend fun <E> tryCatchingStatus(responseObserver: StreamObserver<E>, body: suspend StreamObserver<E>.() -> Unit) {
         try {
             responseObserver.body()
             responseObserver.onCompleted()
-        } catch (t: StatusException) {
-            responseObserver.onError(t)
-        } catch (t: StatusRuntimeException) {
-            responseObserver.onError(t)
-        } catch (t: RuntimeException) {
-            responseObserver.onError(Status.UNKNOWN.asRuntimeException())
-            throw t
-        } catch (t: Exception) {
-            responseObserver.onError(Status.UNKNOWN.asException())
-            throw t
         } catch (t: Throwable) {
-            responseObserver.onError(Status.INTERNAL.asException())
-            throw t
+            handleException(t, responseObserver)
         }
     }
 

--- a/grpc-kotlin-gen/src/main/resources/KtStub.mustache
+++ b/grpc-kotlin-gen/src/main/resources/KtStub.mustache
@@ -123,11 +123,12 @@ object {{className}} {
             responseObserver: StreamObserver<{{outputType}}>
         ) {
             launch {
-                produce {
+                supervisorScope {
                     tryCatchingStatus(responseObserver) {
-                        {{methodName}}(request)
+                        produce { {{methodName}}(request) }
+                            .consumeEach { onNext(it) }
                     }
-                }.consumeEach { responseObserver.onNext(it) }
+                }
             }
         }
         {{/isManyOutput}}
@@ -163,11 +164,12 @@ object {{className}} {
         ): StreamObserver<{{inputType}}> {
             val requestChannel = StreamObserverChannel<{{inputType}}>()
             launch {
-                produce {
+                supervisorScope {
                     tryCatchingStatus(responseObserver) {
-                        {{methodName}}(requestChannel)
+                        produce { {{methodName}}(requestChannel) }
+                            .consumeEach { onNext(it) }
                     }
-                }.consumeEach { responseObserver.onNext(it) }
+                }
             }
             return requestChannel
         }
@@ -201,8 +203,8 @@ object {{className}} {
 
     private fun <E> handleException(t: Throwable?, responseObserver: StreamObserver<E>) {
         when (t) {
-            null -> Unit
-            //is CancellationException -> handleException(t.cause, responseObserver)
+            null -> return
+            is CancellationException -> handleException(t.cause, responseObserver)
             is StatusException, is StatusRuntimeException -> responseObserver.onError(t)
             is RuntimeException -> {
                 responseObserver.onError(Status.UNKNOWN.asRuntimeException())

--- a/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
+++ b/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
@@ -20,8 +20,8 @@
 
 package io.rouz.greeter
 
+import kotlinx.coroutines.experimental.channels.ProducerScope
 import kotlinx.coroutines.experimental.channels.ReceiveChannel
-import kotlinx.coroutines.experimental.channels.produce
 import kotlinx.coroutines.experimental.delay
 import kotlinx.coroutines.experimental.launch
 import kotlinx.coroutines.experimental.newFixedThreadPoolContext
@@ -44,7 +44,7 @@ class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
             .build()
     }
 
-    override suspend fun greetServerStream(request: GreetRequest) = produce<GreetReply> {
+    override suspend fun ProducerScope<GreetReply>.greetServerStream(request: GreetRequest) {
         log.info(request.greeting)
 
         send(
@@ -72,7 +72,7 @@ class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
             .build()
     }
 
-    override suspend fun greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) = produce<GreetReply> {
+    override suspend fun ProducerScope<GreetReply>.greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) {
         var count = 0
 
         for (request in requestChannel) {

--- a/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
+++ b/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
@@ -79,7 +79,7 @@ class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
             val n = count++
             log.info("$n ${request.greeting}")
             launch {
-                delay(1000)
+                delay(100)
                 send(
                     GreetReply.newBuilder()
                         .setReply("Yo #$n ${request.greeting}")

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ClosingStatusExceptionTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ClosingStatusExceptionTest.kt
@@ -1,0 +1,49 @@
+/*-
+ * -\-\-
+ * grpc-kotlin-test
+ * --
+ * Copyright (C) 2016 - 2018 rouz.io
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package io.rouz.greeter
+
+import kotlinx.coroutines.experimental.channels.ProducerScope
+import kotlinx.coroutines.experimental.channels.ReceiveChannel
+
+class ClosingStatusExceptionTest : StatusExceptionTestBase() {
+
+    override val service: GreeterGrpcKt.GreeterImplBase
+        get() = StatusThrowingGreeter()
+
+    private inner class StatusThrowingGreeter : GreeterGrpcKt.GreeterImplBase(collectExceptions) {
+
+        override suspend fun greet(request: GreetRequest): GreetReply {
+            throw notFound("uni")
+        }
+
+        override suspend fun ProducerScope<GreetReply>.greetServerStream(request: GreetRequest) {
+            close(notFound("sstream"))
+        }
+
+        override suspend fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>): GreetReply {
+            throw notFound("cstream")
+        }
+
+        override suspend fun ProducerScope<GreetReply>.greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) {
+            close(notFound("bidi"))
+        }
+    }
+}

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/DelayedClosingStatusExceptionTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/DelayedClosingStatusExceptionTest.kt
@@ -20,6 +20,7 @@
 
 package io.rouz.greeter
 
+import kotlinx.coroutines.experimental.async
 import kotlinx.coroutines.experimental.channels.ProducerScope
 import kotlinx.coroutines.experimental.channels.ReceiveChannel
 import kotlinx.coroutines.experimental.delay
@@ -33,8 +34,10 @@ class DelayedClosingStatusExceptionTest : StatusExceptionTestBase() {
     private inner class StatusThrowingGreeter : GreeterGrpcKt.GreeterImplBase(collectExceptions) {
 
         override suspend fun greet(request: GreetRequest): GreetReply {
-            delay(10)
-            throw notFound("uni")
+            async {
+                delay(10)
+                throw notFound("uni")
+            }.await()
         }
 
         override suspend fun ProducerScope<GreetReply>.greetServerStream(request: GreetRequest) {
@@ -45,8 +48,10 @@ class DelayedClosingStatusExceptionTest : StatusExceptionTestBase() {
         }
 
         override suspend fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>): GreetReply {
-            delay(10)
-            throw notFound("cstream")
+            async {
+                delay(10)
+                throw notFound("cstream")
+            }.await()
         }
 
         override suspend fun ProducerScope<GreetReply>.greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) {

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/DelayedClosingStatusExceptionTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/DelayedClosingStatusExceptionTest.kt
@@ -1,0 +1,59 @@
+/*-
+ * -\-\-
+ * grpc-kotlin-test
+ * --
+ * Copyright (C) 2016 - 2018 rouz.io
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package io.rouz.greeter
+
+import kotlinx.coroutines.experimental.channels.ProducerScope
+import kotlinx.coroutines.experimental.channels.ReceiveChannel
+import kotlinx.coroutines.experimental.delay
+import kotlinx.coroutines.experimental.launch
+
+class DelayedClosingStatusExceptionTest : StatusExceptionTestBase() {
+
+    override val service: GreeterGrpcKt.GreeterImplBase
+        get() = StatusThrowingGreeter()
+
+    private inner class StatusThrowingGreeter : GreeterGrpcKt.GreeterImplBase(collectExceptions) {
+
+        override suspend fun greet(request: GreetRequest): GreetReply {
+            delay(10)
+            throw notFound("uni")
+        }
+
+        override suspend fun ProducerScope<GreetReply>.greetServerStream(request: GreetRequest) {
+            launch {
+                delay(10)
+                close(notFound("sstream"))
+            }
+        }
+
+        override suspend fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>): GreetReply {
+            delay(10)
+            throw notFound("cstream")
+        }
+
+        override suspend fun ProducerScope<GreetReply>.greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) {
+            launch {
+                delay(10)
+                close(notFound("bidi"))
+            }
+        }
+    }
+}

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/DelayedThrowingStatusExceptionTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/DelayedThrowingStatusExceptionTest.kt
@@ -20,6 +20,7 @@
 
 package io.rouz.greeter
 
+import kotlinx.coroutines.experimental.async
 import kotlinx.coroutines.experimental.channels.ProducerScope
 import kotlinx.coroutines.experimental.channels.ReceiveChannel
 import kotlinx.coroutines.experimental.delay
@@ -33,8 +34,10 @@ class DelayedThrowingStatusExceptionTest : StatusExceptionTestBase() {
     private inner class StatusThrowingGreeter : GreeterGrpcKt.GreeterImplBase(collectExceptions) {
 
         override suspend fun greet(request: GreetRequest): GreetReply {
-            delay(10)
-            throw notFound("uni")
+            async {
+                delay(10)
+                throw notFound("uni")
+            }.await()
         }
 
         override suspend fun ProducerScope<GreetReply>.greetServerStream(request: GreetRequest) {
@@ -45,8 +48,10 @@ class DelayedThrowingStatusExceptionTest : StatusExceptionTestBase() {
         }
 
         override suspend fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>): GreetReply {
-            delay(10)
-            throw notFound("cstream")
+            async {
+                delay(10)
+                throw notFound("cstream")
+            }.await()
         }
 
         override suspend fun ProducerScope<GreetReply>.greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) {

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/DelayedThrowingStatusExceptionTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/DelayedThrowingStatusExceptionTest.kt
@@ -1,0 +1,59 @@
+/*-
+ * -\-\-
+ * grpc-kotlin-test
+ * --
+ * Copyright (C) 2016 - 2018 rouz.io
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package io.rouz.greeter
+
+import kotlinx.coroutines.experimental.channels.ProducerScope
+import kotlinx.coroutines.experimental.channels.ReceiveChannel
+import kotlinx.coroutines.experimental.delay
+import kotlinx.coroutines.experimental.launch
+
+class DelayedThrowingStatusExceptionTest : StatusExceptionTestBase() {
+
+    override val service: GreeterGrpcKt.GreeterImplBase
+        get() = StatusThrowingGreeter()
+
+    private inner class StatusThrowingGreeter : GreeterGrpcKt.GreeterImplBase(collectExceptions) {
+
+        override suspend fun greet(request: GreetRequest): GreetReply {
+            delay(10)
+            throw notFound("uni")
+        }
+
+        override suspend fun ProducerScope<GreetReply>.greetServerStream(request: GreetRequest) {
+            launch {
+                delay(10)
+                throw notFound("sstream")
+            }
+        }
+
+        override suspend fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>): GreetReply {
+            delay(10)
+            throw notFound("cstream")
+        }
+
+        override suspend fun ProducerScope<GreetReply>.greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) {
+            launch {
+                delay(10)
+                throw notFound("bidi")
+            }
+        }
+    }
+}

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ExceptionPropagationTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ExceptionPropagationTest.kt
@@ -20,9 +20,7 @@
 
 package io.rouz.greeter
 
-import io.grpc.Status
 import io.grpc.StatusRuntimeException
-import kotlinx.coroutines.experimental.CoroutineExceptionHandler
 import kotlinx.coroutines.experimental.channels.ProducerScope
 import kotlinx.coroutines.experimental.channels.ReceiveChannel
 import kotlinx.coroutines.experimental.runBlocking
@@ -31,6 +29,7 @@ import org.junit.Test
 import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import java.lang.Thread.sleep
 
 @RunWith(JUnit4::class)
 class ExceptionPropagationTest : GrpcTestBase() {
@@ -40,56 +39,8 @@ class ExceptionPropagationTest : GrpcTestBase() {
     val expect = ExpectedException.none()
 
     @Test
-    fun unaryStatus() {
-        val stub = startServer(StatusThrowingGreeter())
-
-        expect.expect(StatusRuntimeException::class.java)
-        expect.expectMessage("NOT_FOUND: uni")
-
-        runBlocking {
-            stub.greet(req("joe"))
-        }
-    }
-
-    @Test
-    fun serverStreamingStatus() {
-        val stub = startServer(StatusThrowingGreeter())
-
-        expect.expect(StatusRuntimeException::class.java)
-        expect.expectMessage("NOT_FOUND: sstream")
-
-        runBlocking {
-            stub.greetServerStream(req("joe")).receive()
-        }
-    }
-
-    @Test
-    fun clientStreamingStatus() {
-        val stub = startServer(StatusThrowingGreeter())
-
-        expect.expect(StatusRuntimeException::class.java)
-        expect.expectMessage("NOT_FOUND: cstream")
-
-        runBlocking {
-            stub.greetClientStream().await()
-        }
-    }
-
-    @Test
-    fun bidirectionalStatus() {
-        val stub = startServer(StatusThrowingGreeter())
-
-        expect.expect(StatusRuntimeException::class.java)
-        expect.expectMessage("NOT_FOUND: bidi")
-
-        runBlocking {
-            stub.greetBidirectional().receive()
-        }
-    }
-
-    @Test
     fun unaryException() {
-        val stub = startServer(GenericThrowingGreeter())
+        val stub = startServer(CustomThrowingGreeter())
 
         expect.expect(StatusRuntimeException::class.java)
         expect.expectMessage("UNKNOWN")
@@ -101,7 +52,7 @@ class ExceptionPropagationTest : GrpcTestBase() {
 
     @Test
     fun serverStreamingException() {
-        val stub = startServer(GenericThrowingGreeter())
+        val stub = startServer(CustomThrowingGreeter())
 
         expect.expect(StatusRuntimeException::class.java)
         expect.expectMessage("UNKNOWN")
@@ -113,7 +64,7 @@ class ExceptionPropagationTest : GrpcTestBase() {
 
     @Test
     fun clientStreamingException() {
-        val stub = startServer(GenericThrowingGreeter())
+        val stub = startServer(CustomThrowingGreeter())
 
         expect.expect(StatusRuntimeException::class.java)
         expect.expectMessage("UNKNOWN")
@@ -125,7 +76,7 @@ class ExceptionPropagationTest : GrpcTestBase() {
 
     @Test
     fun bidirectionalException() {
-        val stub = startServer(GenericThrowingGreeter())
+        val stub = startServer(CustomThrowingGreeter())
 
         expect.expect(StatusRuntimeException::class.java)
         expect.expectMessage("UNKNOWN")
@@ -135,54 +86,100 @@ class ExceptionPropagationTest : GrpcTestBase() {
         }
     }
 
-    private class StatusThrowingGreeter : GreeterGrpcKt.GreeterImplBase(
-        CoroutineExceptionHandler { c, t ->
-            println("caught $t in $c")
+    @Test
+    fun unaryPropagateCustomException() {
+        val stub = startServer(CustomThrowingGreeter())
+
+        expect.expect(CustomThrowingGreeter.CustomException::class.java)
+        expect.expectMessage("my app broke uni")
+
+        try {
+            runBlocking {
+                stub.greet(req("joe"))
+            }
+        } catch (t: Throwable) { // silence
         }
-    ) {
+
+        sleep(100) // wait for worker threads to invoke exception handler
+        throw seenExceptions[0]
+    }
+
+    @Test
+    fun serverStreamingPropagateCustomException() {
+        val stub = startServer(CustomThrowingGreeter())
+
+        expect.expect(CustomThrowingGreeter.CustomException::class.java)
+        expect.expectMessage("my app broke sstream")
+
+        try {
+            runBlocking {
+                stub.greetServerStream(req("jow")).receive()
+            }
+        } catch (t: Throwable) { // silence
+        }
+
+        sleep(100) // wait for worker threads to invoke exception handler
+        throw seenExceptions[0]
+    }
+
+    @Test
+    fun clientStreamingPropagateCustomException() {
+        val stub = startServer(CustomThrowingGreeter())
+
+        expect.expect(CustomThrowingGreeter.CustomException::class.java)
+        expect.expectMessage("my app broke cstream")
+
+        try {
+            runBlocking {
+                stub.greetClientStream().await()
+            }
+        } catch (t: Throwable) { // silence
+        }
+
+        sleep(100) // wait for worker threads to invoke exception handler
+        throw seenExceptions[0]
+    }
+
+    @Test
+    fun bidirectionalPropagateCustomException() {
+        val stub = startServer(CustomThrowingGreeter())
+
+        expect.expect(CustomThrowingGreeter.CustomException::class.java)
+        expect.expectMessage("my app broke bidi")
+
+        try {
+            runBlocking {
+                stub.greetBidirectional().receive()
+            }
+        } catch (t: Throwable) { // silence
+        }
+
+        sleep(100) // wait for worker threads to invoke exception handler
+        throw seenExceptions[0]
+    }
+
+    inner class CustomThrowingGreeter : GreeterGrpcKt.GreeterImplBase(collectExceptions) {
 
         override suspend fun greet(request: GreetRequest): GreetReply {
-            throw notFound("uni")
+            throw broke("uni")
         }
 
         override suspend fun ProducerScope<GreetReply>.greetServerStream(request: GreetRequest) {
-            throw notFound("sstream")
+            throw broke("sstream")
         }
 
         override suspend fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>): GreetReply {
-            throw notFound("cstream")
+            throw broke("cstream")
         }
 
         override suspend fun ProducerScope<GreetReply>.greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) {
-            throw notFound("bidi")
+            throw broke("bidi")
         }
 
-        private fun notFound(description: String): StatusRuntimeException {
-            return Status.NOT_FOUND.withDescription(description).asRuntimeException()
+        private fun broke(description: String): Exception {
+            return CustomException("my app broke $description")
         }
+
+        inner class CustomException(message: String) : Exception(message)
     }
-
-    private class GenericThrowingGreeter : GreeterGrpcKt.GreeterImplBase(SilenceExceptions()) {
-
-        override suspend fun greet(request: GreetRequest): GreetReply {
-            throw broke()
-        }
-
-        override suspend fun ProducerScope<GreetReply>.greetServerStream(request: GreetRequest) {
-            throw broke()
-        }
-
-        override suspend fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>): GreetReply {
-            throw broke()
-        }
-
-        override suspend fun ProducerScope<GreetReply>.greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) {
-            throw broke()
-        }
-
-        private fun broke(): Exception {
-            return Exception("my app broke")
-        }
-    }
-
 }

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/GrpcTestBase.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/GrpcTestBase.kt
@@ -41,8 +41,7 @@ open class GrpcTestBase {
     private val serverName = InProcessServerBuilder.generateName()
 
     protected val seenExceptions = mutableListOf<Throwable>()
-    protected val collectExceptions = CoroutineExceptionHandler {
-            _, t ->
+    protected val collectExceptions = CoroutineExceptionHandler { _, t ->
         seenExceptions += t
         log.info("Caught exception in exception handler: $t")
     }

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/GrpcTestBase.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/GrpcTestBase.kt
@@ -25,7 +25,9 @@ import io.grpc.inprocess.InProcessServerBuilder
 import io.grpc.testing.GrpcCleanupRule
 import io.rouz.greeter.GreeterGrpcKt.GreeterImplBase
 import io.rouz.greeter.GreeterGrpcKt.GreeterKtStub
+import kotlinx.coroutines.experimental.CoroutineExceptionHandler
 import org.junit.Rule
+import kotlin.coroutines.experimental.CoroutineContext
 
 open class GrpcTestBase {
 
@@ -55,5 +57,15 @@ open class GrpcTestBase {
 
     fun req(greeting: String): GreetRequest {
         return GreetRequest.newBuilder().setGreeting(greeting).build()
+    }
+
+    class SilenceExceptions : CoroutineExceptionHandler {
+
+        override val key: CoroutineContext.Key<*>
+            get() = CoroutineExceptionHandler.Key
+
+        override fun handleException(context: CoroutineContext, exception: Throwable) {
+            /* shh */
+        }
     }
 }

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/NoStatusExceptionPropagationTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/NoStatusExceptionPropagationTest.kt
@@ -1,0 +1,57 @@
+/*-
+ * -\-\-
+ * grpc-kotlin-test
+ * --
+ * Copyright (C) 2016 - 2018 rouz.io
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package io.rouz.greeter
+
+import kotlinx.coroutines.experimental.channels.ProducerScope
+import kotlinx.coroutines.experimental.channels.ReceiveChannel
+import org.junit.After
+
+class NoStatusExceptionPropagationTest : StatusExceptionTestBase() {
+
+    override val service: GreeterGrpcKt.GreeterImplBase
+        get() = StatusThrowingGreeter()
+
+    @After
+    fun tearDown() {
+        assert(seenExceptions.isEmpty()) {
+            "Status exceptions should not reach context handler"
+        }
+    }
+
+    private inner class StatusThrowingGreeter : GreeterGrpcKt.GreeterImplBase(collectExceptions) {
+
+        override suspend fun greet(request: GreetRequest): GreetReply {
+            throw notFound("uni")
+        }
+
+        override suspend fun ProducerScope<GreetReply>.greetServerStream(request: GreetRequest) {
+            throw notFound("sstream")
+        }
+
+        override suspend fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>): GreetReply {
+            throw notFound("cstream")
+        }
+
+        override suspend fun ProducerScope<GreetReply>.greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) {
+            throw notFound("bidi")
+        }
+    }
+}

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ThrowingStatusExceptionTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ThrowingStatusExceptionTest.kt
@@ -1,0 +1,49 @@
+/*-
+ * -\-\-
+ * grpc-kotlin-test
+ * --
+ * Copyright (C) 2016 - 2018 rouz.io
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package io.rouz.greeter
+
+import kotlinx.coroutines.experimental.channels.ProducerScope
+import kotlinx.coroutines.experimental.channels.ReceiveChannel
+
+class ThrowingStatusExceptionTest : StatusExceptionTestBase() {
+
+    override val service: GreeterGrpcKt.GreeterImplBase
+        get() = StatusThrowingGreeter()
+
+    private inner class StatusThrowingGreeter : GreeterGrpcKt.GreeterImplBase(collectExceptions) {
+
+        override suspend fun greet(request: GreetRequest): GreetReply {
+            throw notFound("uni")
+        }
+
+        override suspend fun ProducerScope<GreetReply>.greetServerStream(request: GreetRequest) {
+            throw notFound("sstream")
+        }
+
+        override suspend fun greetClientStream(requestChannel: ReceiveChannel<GreetRequest>): GreetReply {
+            throw notFound("cstream")
+        }
+
+        override suspend fun ProducerScope<GreetReply>.greetBidirectional(requestChannel: ReceiveChannel<GreetRequest>) {
+            throw notFound("bidi")
+        }
+    }
+}

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/UnimplementedStatusTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/UnimplementedStatusTest.kt
@@ -80,5 +80,5 @@ class UnimplementedStatusTest : GrpcTestBase() {
         }
     }
 
-    class UnimplementedGreeter : GreeterGrpcKt.GreeterImplBase()
+    class UnimplementedGreeter : GreeterGrpcKt.GreeterImplBase(SilenceExceptions())
 }


### PR DESCRIPTION
This switches the signature on server streaming handlers to be executed within a `ProducerScope<TReply>`.

```diff
-  override suspend fun greetServerStream(request: TRequest) = produce<TReply> { ... }
+  override suspend fun ProducerScope<TReply>.greetServerStream(request: TRequest) { ... }
```

It also makes exception propagation more consistent across the various rpc types by always following these rules:

- Exceptions thrown from rpc handlers will either:
  - complete the request and send a status to the caller, if they are instance of `StatusException` or `StatusRuntimeException`
  - complete the request with a status `UNKNOWN` or `INTERNAL`, and propagated to the `CoroutineScope` that is used in the service constructor