### PR TITLE
Parameterize server send channel capacity

### DIFF
--- a/grpc-kotlin-gen/src/main/resources/KtStub.mustache
+++ b/grpc-kotlin-gen/src/main/resources/KtStub.mustache
@@ -87,7 +87,8 @@ object {{className}} {
 
     {{#javaDoc}}{{{javaDoc}}}{{/javaDoc}}
     abstract class {{serviceName}}ImplBase(
-        override val coroutineContext: CoroutineContext = Dispatchers.Default
+        override val coroutineContext: CoroutineContext = Dispatchers.Default,
+        val sendChannelCapacity: Int = KtChannel.UNLIMITED
     ) : BindableService, CoroutineScope {
 
         {{#methods}}
@@ -125,8 +126,11 @@ object {{className}} {
             launch {
                 supervisorScope {
                     tryCatchingStatus(responseObserver) {
-                        produce { {{methodName}}(request) }
-                            .consumeEach { onNext(it) }
+                        produce(capacity = sendChannelCapacity) {
+                            {{methodName}}(request)
+                        }.consumeEach {
+                            onNext(it)
+                        }
                     }
                 }
             }
@@ -166,8 +170,11 @@ object {{className}} {
             launch {
                 supervisorScope {
                     tryCatchingStatus(responseObserver) {
-                        produce { {{methodName}}(requestChannel) }
-                            .consumeEach { onNext(it) }
+                        produce(capacity = sendChannelCapacity) {
+                            {{methodName}}(requestChannel)
+                        }.consumeEach {
+                            onNext(it)
+                        }
                     }
                 }
             }

--- a/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
+++ b/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
@@ -31,7 +31,8 @@ import mu.KotlinLogging
  * Implementation of coroutine-based gRPC service defined in greeter.proto
  */
 class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
-    coroutineContext = newFixedThreadPoolContext(4, "server-pool")
+    coroutineContext = newFixedThreadPoolContext(4, "server-pool"),
+    sendChannelCapacity = 4
 ) {
 
     private val log = KotlinLogging.logger("server")


### PR DESCRIPTION
This allows a server implementation to specify the channel capacity of channels created for server streaming calls. Defaults to `Channel.UNLIMITED`.

```kotlin
class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
    sendChannelCapacity = 4
) {
    // server handlers
}
```