### PR TITLE
gRPC context should be propagated to service code

### DIFF
--- a/grpc-kotlin-gen/src/main/resources/KtStub.mustache
+++ b/grpc-kotlin-gen/src/main/resources/KtStub.mustache
@@ -105,7 +105,7 @@ object {{className}} {
             request: {{inputType}},
             responseObserver: StreamObserver<{{outputType}}>
         ) {
-            launch {
+            launch (ContextCoroutineContextElement()) {
                 tryCatchingStatus(responseObserver) {
                     val response = {{methodName}}(request)
                     onNext(response)
@@ -123,7 +123,7 @@ object {{className}} {
             request: {{inputType}},
             responseObserver: StreamObserver<{{outputType}}>
         ) {
-            launch {
+            launch (ContextCoroutineContextElement()) {
                 tryCatchingStatus(responseObserver) {
                     val responses = {{methodName}}(request)
                     for (response in responses) {
@@ -145,7 +145,7 @@ object {{className}} {
             responseObserver: StreamObserver<{{outputType}}>
         ): StreamObserver<{{inputType}}> {
             val requests = StreamObserverChannel<{{inputType}}>()
-            launch {
+            launch (ContextCoroutineContextElement()) {
                 tryCatchingStatus(responseObserver) {
                     val response = {{methodName}}(requests)
                     onNext(response)
@@ -164,7 +164,7 @@ object {{className}} {
             responseObserver: StreamObserver<{{outputType}}>
         ): StreamObserver<{{inputType}}> {
             val requests = StreamObserverChannel<{{inputType}}>()
-            launch {
+            launch (ContextCoroutineContextElement()) {
                 tryCatchingStatus(responseObserver) {
                     val responses = {{methodName}}(requests)
                     for (response in responses) {
@@ -281,6 +281,16 @@ object {{className}} {
         override fun onCompleted() { channel.close(cause = null) }
     }
 
+    private class ContextCoroutineContextElement : ThreadContextElement<Context> {
+        private val grpcContext: Context = Context.current()
+        companion object Key : CoroutineContext.Key<ContextCoroutineContextElement>
+
+        override val key: CoroutineContext.Key<ContextCoroutineContextElement>
+            get() = Key
+
+        override fun updateThreadContext(context: CoroutineContext): Context = grpcContext.attach()
+        override fun restoreThreadContext(context: CoroutineContext, oldState: Context) = grpcContext.detach(oldState)
+    }
     {{#methods}}
     val METHODID_{{methodNameUpperUnderscore}} = {{methodNumber}}
     {{/methods}}

--- a/grpc-kotlin-gen/src/main/resources/KtStub.mustache
+++ b/grpc-kotlin-gen/src/main/resources/KtStub.mustache
@@ -87,9 +87,12 @@ object {{className}} {
 
     {{#javaDoc}}{{{javaDoc}}}{{/javaDoc}}
     abstract class {{serviceName}}ImplBase(
-        override val coroutineContext: CoroutineContext = Dispatchers.Default,
+        private val _coroutineContext: CoroutineContext = Dispatchers.Default,
         val sendChannelCapacity: Int = KtChannel.UNLIMITED
     ) : BindableService, CoroutineScope {
+
+        override val coroutineContext: CoroutineContext
+            get() = _coroutineContext + ContextCoroutineContextElement()
 
         {{#methods}}
         {{#javaDoc}}{{{javaDoc}}}{{/javaDoc}}
@@ -105,7 +108,7 @@ object {{className}} {
             request: {{inputType}},
             responseObserver: StreamObserver<{{outputType}}>
         ) {
-            launch (ContextCoroutineContextElement()) {
+            launch {
                 tryCatchingStatus(responseObserver) {
                     val response = {{methodName}}(request)
                     onNext(response)
@@ -123,7 +126,7 @@ object {{className}} {
             request: {{inputType}},
             responseObserver: StreamObserver<{{outputType}}>
         ) {
-            launch (ContextCoroutineContextElement()) {
+            launch {
                 tryCatchingStatus(responseObserver) {
                     val responses = {{methodName}}(request)
                     for (response in responses) {
@@ -145,7 +148,7 @@ object {{className}} {
             responseObserver: StreamObserver<{{outputType}}>
         ): StreamObserver<{{inputType}}> {
             val requests = StreamObserverChannel<{{inputType}}>()
-            launch (ContextCoroutineContextElement()) {
+            launch {
                 tryCatchingStatus(responseObserver) {
                     val response = {{methodName}}(requests)
                     onNext(response)
@@ -164,7 +167,7 @@ object {{className}} {
             responseObserver: StreamObserver<{{outputType}}>
         ): StreamObserver<{{inputType}}> {
             val requests = StreamObserverChannel<{{inputType}}>()
-            launch (ContextCoroutineContextElement()) {
+            launch {
                 tryCatchingStatus(responseObserver) {
                     val responses = {{methodName}}(requests)
                     for (response in responses) {

--- a/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
+++ b/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
@@ -34,7 +34,7 @@ import java.util.concurrent.Executors.newFixedThreadPool
  */
 @UseExperimental(ExperimentalCoroutinesApi::class)
 class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
-    coroutineContext = newFixedThreadPool(4).asCoroutineDispatcher(),
+    _coroutineContext = newFixedThreadPool(4).asCoroutineDispatcher(),
     sendChannelCapacity = 4
 ) {
 

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ContextBasedGreeterTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ContextBasedGreeterTest.kt
@@ -1,0 +1,133 @@
+/*-
+ * -\-\-
+ * grpc-kotlin-test
+ * --
+ * Copyright (C) 2016 - 2018 rouz.io
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package io.rouz.greeter
+
+import io.grpc.Context
+import io.grpc.Contexts
+import io.grpc.Metadata
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
+import io.grpc.stub.MetadataUtils
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.produce
+import kotlinx.coroutines.channels.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+import org.junit.Test
+
+class ContextBasedGreeterTest : GrpcTestBase() {
+  companion object {
+    private val userContextKey = Context.key<String>("user name")
+    private val userMetadataKey = Metadata.Key.of("User-Name", Metadata.ASCII_STRING_MARSHALLER)
+  }
+
+  @Test
+  fun contextValueMissing() {
+    val stub = startServer(ContextGreeter)
+
+    runBlocking {
+      val reply = stub.greet(req("rouz"))
+
+      Assert.assertEquals("Hello anonymous", reply.reply)
+    }
+  }
+
+  @Test
+  fun contextValuePresent() {
+    val stub = MetadataUtils.attachHeaders(
+        startServer(ContextGreeter),
+        Metadata().apply { put(userMetadataKey, "Chad") }
+    )
+
+    runBlocking {
+      val reply = stub.greet(req("rouz"))
+
+      Assert.assertEquals("Hello Chad", reply.reply)
+    }
+  }
+
+  @Test
+  fun contextTransferredAcrossThreads() {
+    /*
+     * This test is intended to ensure that the context gets transferred as expected to child coroutines and multiple
+     * threads. We ensure this by having the service include the thread ID in the reply and verifying that more than
+     * one thread issued replies.
+     */
+    val stub = MetadataUtils.attachHeaders(
+        startServer(ContextGreeter),
+        Metadata().apply { put(userMetadataKey, "Jordan") }
+    )
+
+    runBlocking {
+      val replies = stub.greetServerStream(req("rouz")).toList()
+
+      val regex = Regex("Hi #\\d{1,3} Jordan from (\\d+)")
+      val threadIds = replies
+          .map { regex.matchEntire(it.reply) }
+          .onEach { Assert.assertNotNull("Reply did not match '${regex.pattern}'", it) }.filterNotNull()
+          .map { it.groups[1]?.value }
+          .onEach { Assert.assertNotNull(it) }.filterNotNull()
+          .toSet()
+      Assert.assertNotEquals("All messages were dispatched by a single thread", 1, threadIds.size)
+    }
+  }
+
+  override fun serverInterceptor(): ServerInterceptor = ServerNameInterceptor
+
+  object ContextGreeter : GreeterGrpcKt.GreeterImplBase() {
+    override suspend fun greet(request: GreetRequest): GreetReply =
+        GreetReply.newBuilder()
+            .setReply("Hello ${userContextKey.get() ?: "anonymous"}")
+            .build()
+
+    @ExperimentalCoroutinesApi
+    override suspend fun greetServerStream(request: GreetRequest): ReceiveChannel<GreetReply> = produce {
+      (0..99).map {
+        async {
+          send(
+              GreetReply.newBuilder()
+                  .setReply("Hi #$it ${userContextKey.get()} from ${Thread.currentThread().id}")
+                  .build()
+          )
+        }
+      }.forEach { it.await() }
+    }
+  }
+
+  object ServerNameInterceptor : ServerInterceptor {
+    override fun <ReqT : Any?, RespT : Any?> interceptCall(
+        call: ServerCall<ReqT, RespT>,
+        headers: Metadata,
+        next: ServerCallHandler<ReqT, RespT>
+    ): ServerCall.Listener<ReqT> = headers[userMetadataKey]
+        ?.let {
+          Contexts.interceptCall(
+              Context.current().withValue(userContextKey, it),
+              call,
+              headers,
+              next
+          )
+        } ?: next.startCall(call, headers)
+  }
+}


### PR DESCRIPTION
gRPC uses a io.grpc.Context class to make metadata about a call available to implementation code. The context of a call is stored in a ThreadLocal allowing it to be easily accessed within the service method call. Kotlin coroutines do not run on a single, predictable thread, making this storage insufficient. Fortunately, Kotlin provides an easy way to adapt this thread local pattern to a CoroutineContext, which is implemented in this commit.