### PR TITLE
Generate base class as a top level class

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ Run the protoc plugin to get the generated code, see [build tool configuration](
 
 ### Server
 
-After compilation, you'll find the generated Kotlin stubs in an `object` named `GreeterGrpcKt`. Both
-the service base class and client stub will use `suspend` and `Channel<T>` instead of the typical
-`StreamObserver<T>` interfaces.
+After compilation, you'll find the generated Kotlin code in the same package as the generated Java
+code. A service base class named `GreeterImplBase` and a file with extension functions for the
+client stub named `GreeterStubExt.kt`. Both the service base class and client stub extensions will
+use `suspend` and `Channel<T>` instead of the typical `StreamObserver<T>` interfaces.
 
 All functions have the [`suspend`] modifier so they can call into any suspending code, including the
 [core coroutine primitives] like `delay` and `async`.
@@ -99,7 +100,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.produce
 import java.util.concurrent.Executors.newFixedThreadPool
 
-class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
+class GreeterImpl : GreeterImplBase(
   coroutineContext = newFixedThreadPool(4).asCoroutineDispatcher()
 ) {
 

--- a/grpc-kotlin-gen/src/main/java/io/rouz/grpc/kotlin/GrpcKotlinGenerator.java
+++ b/grpc-kotlin-gen/src/main/java/io/rouz/grpc/kotlin/GrpcKotlinGenerator.java
@@ -51,7 +51,7 @@ import static com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse;
 public class GrpcKotlinGenerator extends Generator {
 
   private static final int METHOD_NUMBER_OF_PATHS = 4;
-  private static final String CLASS_SUFFIX = "GrpcKt";
+  private static final String CLASS_SUFFIX = "ImplBase";
   private static final String STUB_SUFFIX = "StubExt";
   private static final String ADAPTERS_FILE_PATH = "io/rouz/grpc/Adapters.kt";
   private static final String SERVICE_JAVA_DOC_PREFIX = "    ";
@@ -115,7 +115,6 @@ public class GrpcKotlinGenerator extends Generator {
       int serviceNumber) {
 
     Context context = new Context();
-    context.className = serviceProto.getName() + CLASS_SUFFIX;
     context.serviceName = serviceProto.getName();
     context.deprecated = serviceProto.getOptions() != null
         && serviceProto.getOptions().getDeprecated();
@@ -240,10 +239,9 @@ public class GrpcKotlinGenerator extends Generator {
    * Template class for proto Service objects.
    */
   private class Context {
-    // CHECKSTYLE DISABLE VisibilityModifier FOR 7 LINES
+    // CHECKSTYLE DISABLE VisibilityModifier FOR 6 LINES
     public String protoName;
     public String packageName;
-    public String className;
     public String serviceName;
     public boolean deprecated;
     public String javaDoc;

--- a/grpc-kotlin-gen/src/main/resources/ImplBase.mustache
+++ b/grpc-kotlin-gen/src/main/resources/ImplBase.mustache
@@ -12,122 +12,119 @@ import kotlin.coroutines.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 
+{{#javaDoc}}{{{javaDoc}}}{{/javaDoc}}
 {{#deprecated}}@Deprecated("deprecated"){{/deprecated}}
 @javax.annotation.Generated(
     value = ["by gRPC Kotlin generator"],
     comments = "Source: {{protoName}}"
 )
-object {{className}} {
+abstract class {{serviceName}}ImplBase(
+    coroutineContext: CoroutineContext = Dispatchers.Default
+) : BindableService, CoroutineScope {
 
+    private val _coroutineContext: CoroutineContext = coroutineContext
+
+    override val coroutineContext: CoroutineContext
+        get() = ContextCoroutineContextElement() + _coroutineContext
+
+    {{#methods}}
     {{#javaDoc}}{{{javaDoc}}}{{/javaDoc}}
-    abstract class {{serviceName}}ImplBase(
-        coroutineContext: CoroutineContext = Dispatchers.Default
-    ) : BindableService, CoroutineScope {
+    {{#deprecated}}@Deprecated("deprecated"){{/deprecated}}
+    {{^isManyInput}}
+    {{^isManyOutput}}
+    {{! == unary req, unary resp == }}
+    open suspend fun {{methodName}}(request: {{inputType}}): {{outputType}} {
+        throw unimplemented(get{{methodNamePascalCase}}Method()).asRuntimeException()
+    }
 
-        private val _coroutineContext: CoroutineContext = coroutineContext
-
-        override val coroutineContext: CoroutineContext
-            get() = ContextCoroutineContextElement() + _coroutineContext
-
-        {{#methods}}
-        {{#javaDoc}}{{{javaDoc}}}{{/javaDoc}}
-        {{#deprecated}}@Deprecated("deprecated"){{/deprecated}}
-        {{^isManyInput}}
-        {{^isManyOutput}}
-        {{! == unary req, unary resp == }}
-        open suspend fun {{methodName}}(request: {{inputType}}): {{outputType}} {
-            throw unimplemented(get{{methodNamePascalCase}}Method()).asRuntimeException()
+    internal fun {{methodName}}Internal(
+        request: {{inputType}},
+        responseObserver: StreamObserver<{{outputType}}>
+    ) {
+        launch {
+            tryCatchingStatus(responseObserver) {
+                val response = {{methodName}}(request)
+                onNext(response)
+            }
         }
+    }
+    {{/isManyOutput}}
+    {{#isManyOutput}}
+    {{! == unary req, streaming resp == }}
+    open suspend fun {{methodName}}(request: {{inputType}}): ReceiveChannel<{{outputType}}> {
+        throw unimplemented(get{{methodNamePascalCase}}Method()).asRuntimeException()
+    }
 
-        internal fun {{methodName}}Internal(
-            request: {{inputType}},
-            responseObserver: StreamObserver<{{outputType}}>
-        ) {
-            launch {
-                tryCatchingStatus(responseObserver) {
-                    val response = {{methodName}}(request)
+    internal fun {{methodName}}Internal(
+        request: {{inputType}},
+        responseObserver: StreamObserver<{{outputType}}>
+    ) {
+        launch {
+            tryCatchingStatus(responseObserver) {
+                val responses = {{methodName}}(request)
+                for (response in responses) {
+                  onNext(response)
+                }
+            }
+        }
+    }
+    {{/isManyOutput}}
+    {{/isManyInput}}
+    {{#isManyInput}}
+    {{^isManyOutput}}
+    {{! == streaming req, unary resp == }}
+    open suspend fun {{methodName}}(requests: ReceiveChannel<{{inputType}}>): {{outputType}} {
+        throw unimplemented(get{{methodNamePascalCase}}Method()).asRuntimeException()
+    }
+
+    internal fun {{methodName}}Internal(
+        responseObserver: StreamObserver<{{outputType}}>
+    ): StreamObserver<{{inputType}}> {
+        val requests = StreamObserverChannel<{{inputType}}>()
+        launch {
+            tryCatchingStatus(responseObserver) {
+                val response = {{methodName}}(requests)
+                onNext(response)
+            }
+        }
+        return requests
+    }
+    {{/isManyOutput}}
+    {{#isManyOutput}}
+    {{! == streaming req, streaming resp == }}
+    open suspend fun {{methodName}}(requests: ReceiveChannel<{{inputType}}>): ReceiveChannel<{{outputType}}> {
+        throw unimplemented(get{{methodNamePascalCase}}Method()).asRuntimeException()
+    }
+
+    internal fun {{methodName}}Internal(
+        responseObserver: StreamObserver<{{outputType}}>
+    ): StreamObserver<{{inputType}}> {
+        val requests = StreamObserverChannel<{{inputType}}>()
+        launch {
+            tryCatchingStatus(responseObserver) {
+                val responses = {{methodName}}(requests)
+                for (response in responses) {
                     onNext(response)
                 }
             }
         }
-        {{/isManyOutput}}
-        {{#isManyOutput}}
-        {{! == unary req, streaming resp == }}
-        open suspend fun {{methodName}}(request: {{inputType}}): ReceiveChannel<{{outputType}}> {
-            throw unimplemented(get{{methodNamePascalCase}}Method()).asRuntimeException()
-        }
+        return requests
+    }
+    {{/isManyOutput}}
+    {{/isManyInput}}
+    {{/methods}}
 
-        internal fun {{methodName}}Internal(
-            request: {{inputType}},
-            responseObserver: StreamObserver<{{outputType}}>
-        ) {
-            launch {
-                tryCatchingStatus(responseObserver) {
-                    val responses = {{methodName}}(request)
-                    for (response in responses) {
-                      onNext(response)
-                    }
-                }
-            }
-        }
-        {{/isManyOutput}}
-        {{/isManyInput}}
-        {{#isManyInput}}
-        {{^isManyOutput}}
-        {{! == streaming req, unary resp == }}
-        open suspend fun {{methodName}}(requests: ReceiveChannel<{{inputType}}>): {{outputType}} {
-            throw unimplemented(get{{methodNamePascalCase}}Method()).asRuntimeException()
-        }
-
-        internal fun {{methodName}}Internal(
-            responseObserver: StreamObserver<{{outputType}}>
-        ): StreamObserver<{{inputType}}> {
-            val requests = StreamObserverChannel<{{inputType}}>()
-            launch {
-                tryCatchingStatus(responseObserver) {
-                    val response = {{methodName}}(requests)
-                    onNext(response)
-                }
-            }
-            return requests
-        }
-        {{/isManyOutput}}
-        {{#isManyOutput}}
-        {{! == streaming req, streaming resp == }}
-        open suspend fun {{methodName}}(requests: ReceiveChannel<{{inputType}}>): ReceiveChannel<{{outputType}}> {
-            throw unimplemented(get{{methodNamePascalCase}}Method()).asRuntimeException()
-        }
-
-        internal fun {{methodName}}Internal(
-            responseObserver: StreamObserver<{{outputType}}>
-        ): StreamObserver<{{inputType}}> {
-            val requests = StreamObserverChannel<{{inputType}}>()
-            launch {
-                tryCatchingStatus(responseObserver) {
-                    val responses = {{methodName}}(requests)
-                    for (response in responses) {
-                        onNext(response)
-                    }
-                }
-            }
-            return requests
-        }
-        {{/isManyOutput}}
-        {{/isManyInput}}
-        {{/methods}}
-
-        override fun bindService(): ServerServiceDefinition {
-            return ServerServiceDefinition.builder(getServiceDescriptor())
-                {{#methods}}
-                .addMethod(
-                    get{{methodNamePascalCase}}Method(),
-                    ServerCalls.{{grpcCallsMethodName}}(
-                        MethodHandlers(this, METHODID_{{methodNameUpperUnderscore}})
-                    )
+    override fun bindService(): ServerServiceDefinition {
+        return ServerServiceDefinition.builder(getServiceDescriptor())
+            {{#methods}}
+            .addMethod(
+                get{{methodNamePascalCase}}Method(),
+                ServerCalls.{{grpcCallsMethodName}}(
+                    MethodHandlers(METHODID_{{methodNameUpperUnderscore}})
                 )
-                {{/methods}}
-                .build()
-        }
+            )
+            {{/methods}}
+            .build()
     }
 
     private fun unimplemented(methodDescriptor: MethodDescriptor<*, *>): Status {
@@ -165,11 +162,10 @@ object {{className}} {
     }
 
     {{#methods}}
-    private const val METHODID_{{methodNameUpperUnderscore}} = {{methodNumber}}
+    private val METHODID_{{methodNameUpperUnderscore}} = {{methodNumber}}
     {{/methods}}
 
-    private class MethodHandlers<Req, Resp> internal constructor(
-        private val serviceImpl: {{serviceName}}ImplBase,
+    private inner class MethodHandlers<Req, Resp> internal constructor(
         private val methodId: Int
     ) : ServerCalls.UnaryMethod<Req, Resp>,
         ServerCalls.ServerStreamingMethod<Req, Resp>,
@@ -182,7 +178,7 @@ object {{className}} {
                 {{#methods}}
                 {{^isManyInput}}
                 METHODID_{{methodNameUpperUnderscore}} ->
-                    serviceImpl.{{methodName}}Internal(
+                    this@{{serviceName}}ImplBase.{{methodName}}Internal(
                         request as {{inputType}},
                         responseObserver as StreamObserver<{{outputType}}>
                     )
@@ -198,7 +194,7 @@ object {{className}} {
                 {{#methods}}
                 {{#isManyInput}}
                 METHODID_{{methodNameUpperUnderscore}} ->
-                    return serviceImpl.{{methodName}}Internal(
+                    return this@{{serviceName}}ImplBase.{{methodName}}Internal(
                         responseObserver as StreamObserver<{{outputType}}>
                     ) as StreamObserver<Req>
                 {{/isManyInput}}

--- a/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
+++ b/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
@@ -33,7 +33,7 @@ import java.util.concurrent.Executors.newFixedThreadPool
  * Implementation of coroutine-based gRPC service defined in greeter.proto
  */
 @UseExperimental(ExperimentalCoroutinesApi::class)
-class GreeterImpl : GreeterGrpcKt.GreeterImplBase(
+class GreeterImpl : GreeterImplBase(
     coroutineContext = newFixedThreadPool(4, threadFactory("server-worker-%d")).asCoroutineDispatcher()
 ) {
 

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ClosingStatusExceptionTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ClosingStatusExceptionTest.kt
@@ -26,11 +26,11 @@ import kotlinx.coroutines.channels.produce
 
 class ClosingStatusExceptionTest : StatusExceptionTestBase() {
 
-    override val service: GreeterGrpcKt.GreeterImplBase
+    override val service: GreeterImplBase
         get() = StatusThrowingGreeter()
 
     @UseExperimental(ExperimentalCoroutinesApi::class)
-    private inner class StatusThrowingGreeter : GreeterGrpcKt.GreeterImplBase(collectExceptions) {
+    private inner class StatusThrowingGreeter : GreeterImplBase(collectExceptions) {
 
         override suspend fun greet(request: GreetRequest): GreetReply {
             throw notFound("uni")

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ContextBasedGreeterTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ContextBasedGreeterTest.kt
@@ -96,7 +96,7 @@ class ContextBasedGreeterTest : GrpcTestBase() {
 
     override fun serverInterceptor(): ServerInterceptor = ServerNameInterceptor
 
-    inner class ContextGreeter : GreeterGrpcKt.GreeterImplBase() {
+    inner class ContextGreeter : GreeterImplBase() {
         override suspend fun greet(request: GreetRequest): GreetReply =
             repl("Hello ${userContextKey.get() ?: "anonymous"}")
 

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/DelayedClosingStatusExceptionTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/DelayedClosingStatusExceptionTest.kt
@@ -30,11 +30,11 @@ import kotlinx.coroutines.launch
 
 class DelayedClosingStatusExceptionTest : StatusExceptionTestBase() {
 
-    override val service: GreeterGrpcKt.GreeterImplBase
+    override val service: GreeterImplBase
         get() = StatusThrowingGreeter()
 
     @UseExperimental(ExperimentalCoroutinesApi::class)
-    private inner class StatusThrowingGreeter : GreeterGrpcKt.GreeterImplBase(collectExceptions) {
+    private inner class StatusThrowingGreeter : GreeterImplBase(collectExceptions) {
 
         override suspend fun greet(request: GreetRequest): GreetReply {
             async {

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/DelayedThrowingStatusExceptionTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/DelayedThrowingStatusExceptionTest.kt
@@ -30,11 +30,11 @@ import kotlinx.coroutines.launch
 @UseExperimental(ExperimentalCoroutinesApi::class)
 class DelayedThrowingStatusExceptionTest : StatusExceptionTestBase() {
 
-    override val service: GreeterGrpcKt.GreeterImplBase
+    override val service: GreeterImplBase
         get() = StatusThrowingGreeter()
 
     @UseExperimental(ExperimentalCoroutinesApi::class)
-    private inner class StatusThrowingGreeter : GreeterGrpcKt.GreeterImplBase(collectExceptions) {
+    private inner class StatusThrowingGreeter : GreeterImplBase(collectExceptions) {
 
         override suspend fun greet(request: GreetRequest): GreetReply {
             async {

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ExceptionPropagationTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ExceptionPropagationTest.kt
@@ -160,7 +160,7 @@ class ExceptionPropagationTest : GrpcTestBase() {
     }
 
     @UseExperimental(ExperimentalCoroutinesApi::class)
-    private inner class CustomThrowingGreeter : GreeterGrpcKt.GreeterImplBase(collectExceptions) {
+    private inner class CustomThrowingGreeter : GreeterImplBase(collectExceptions) {
 
         override suspend fun greet(request: GreetRequest): GreetReply {
             throw broke("uni")

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/GrpcTestBase.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/GrpcTestBase.kt
@@ -28,7 +28,6 @@ import io.grpc.inprocess.InProcessChannelBuilder
 import io.grpc.inprocess.InProcessServerBuilder
 import io.grpc.testing.GrpcCleanupRule
 import io.rouz.greeter.GreeterGrpc.GreeterStub
-import io.rouz.greeter.GreeterGrpcKt.GreeterImplBase
 import kotlinx.coroutines.CoroutineExceptionHandler
 import mu.KotlinLogging
 import org.junit.Rule

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/NoStatusExceptionPropagationTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/NoStatusExceptionPropagationTest.kt
@@ -27,7 +27,7 @@ import org.junit.After
 
 class NoStatusExceptionPropagationTest : StatusExceptionTestBase() {
 
-    override val service: GreeterGrpcKt.GreeterImplBase
+    override val service: GreeterImplBase
         get() = StatusThrowingGreeter()
 
     @After
@@ -38,7 +38,7 @@ class NoStatusExceptionPropagationTest : StatusExceptionTestBase() {
     }
 
     @UseExperimental(ExperimentalCoroutinesApi::class)
-    private inner class StatusThrowingGreeter : GreeterGrpcKt.GreeterImplBase(collectExceptions) {
+    private inner class StatusThrowingGreeter : GreeterImplBase(collectExceptions) {
 
         override suspend fun greet(request: GreetRequest): GreetReply {
             throw notFound("uni")

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/StatusExceptionTestBase.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/StatusExceptionTestBase.kt
@@ -33,7 +33,7 @@ abstract class StatusExceptionTestBase : GrpcTestBase() {
     @JvmField
     val expect = ExpectedException.none()
 
-    abstract val service: GreeterGrpcKt.GreeterImplBase
+    abstract val service: GreeterImplBase
 
     @Test
     fun unaryStatus() {

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ThrowingStatusExceptionTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ThrowingStatusExceptionTest.kt
@@ -26,11 +26,11 @@ import kotlinx.coroutines.channels.produce
 
 class ThrowingStatusExceptionTest : StatusExceptionTestBase() {
 
-    override val service: GreeterGrpcKt.GreeterImplBase
+    override val service: GreeterImplBase
         get() = StatusThrowingGreeter()
 
     @UseExperimental(ExperimentalCoroutinesApi::class)
-    private inner class StatusThrowingGreeter : GreeterGrpcKt.GreeterImplBase(collectExceptions) {
+    private inner class StatusThrowingGreeter : GreeterImplBase(collectExceptions) {
 
         override suspend fun greet(request: GreetRequest): GreetReply {
             throw notFound("uni")

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/UnimplementedStatusTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/UnimplementedStatusTest.kt
@@ -80,5 +80,5 @@ class UnimplementedStatusTest : GrpcTestBase() {
         }
     }
 
-    inner class UnimplementedGreeter : GreeterGrpcKt.GreeterImplBase(collectExceptions)
+    inner class UnimplementedGreeter : GreeterImplBase(collectExceptions)
 }


### PR DESCRIPTION
Removing the package-type object named `<Service>GrpcKt` as it only served as a namespace object, which is discouraged. The generated code now produces a top level abstract class named `<Service>ImplBase` which encapsulates the internal `MethodHandler` and other functions as inner private classes/functions.

Any code that referenced the outer object can now just directly reference the `*ImplBase` class.

```diff
- class GreeterImpl : GreeterGrpcKt.GreeterImplBase() {
+ class GreeterImpl : GreeterImplBase() {
```