### PR TITLE
Prevent nested comments in Kotlin comments generated from prtobuf comments

### DIFF
--- a/grpc-kotlin-gen/src/main/java/io/rouz/grpc/kotlin/GrpcKotlinGenerator.java
+++ b/grpc-kotlin-gen/src/main/java/io/rouz/grpc/kotlin/GrpcKotlinGenerator.java
@@ -227,6 +227,9 @@ public class GrpcKotlinGenerator extends Generator {
       StringBuilder builder = new StringBuilder("/**\n")
           .append(prefix).append(" * <pre>\n");
       Arrays.stream(HtmlEscapers.htmlEscaper().escape(comments).split("\n"))
+          // Kotlin allows nested block comments, so any occurrence of '/*' would begin
+          // a nested block, breaking the generated code.
+          .map(line -> line.replace("/*", "/&#42;"))
           .forEach(line -> builder.append(prefix).append(" * ").append(line).append("\n"));
       builder
           .append(prefix).append(" * <pre>\n")


### PR DESCRIPTION
Fixes #35 

Prevent creation of javadoc comment blocks with nested comment blocks caused by `/*` contained in comments in protobuf files.