### PR TITLE
Prevent nested comments in kotlin

### DIFF
--- a/grpc-kotlin-gen/src/main/java/io/rouz/grpc/kotlin/GrpcKotlinGenerator.java
+++ b/grpc-kotlin-gen/src/main/java/io/rouz/grpc/kotlin/GrpcKotlinGenerator.java
@@ -227,6 +227,10 @@ public class GrpcKotlinGenerator extends Generator {
       StringBuilder builder = new StringBuilder("/**\n")
           .append(prefix).append(" * <pre>\n");
       Arrays.stream(HtmlEscapers.htmlEscaper().escape(comments).split("\n"))
+          // Kotlin allows nested block comments, so any occurrence of '/*' would begin
+          // a nested block, breaking the generated code.
+          .map(line -> line.replace("/*", "/&#42;"))
+          .map(line -> line.replace("*/", "*&#47;"))
           .forEach(line -> builder.append(prefix).append(" * ").append(line).append("\n"));
       builder
           .append(prefix).append(" * <pre>\n")

--- a/grpc-kotlin-test/src/main/proto/io/rouz/greeter.proto
+++ b/grpc-kotlin-test/src/main/proto/io/rouz/greeter.proto
@@ -13,6 +13,9 @@ message GreetReply {
 }
 
 service Greeter {
+    // Adding some comments to ensure correct parsing with respect to kotlin nested block comments
+    // /* That should get escaped so that it doesn't start a block comment
+    // */ That should also get escaped so that it doesn't terminate a javadoc comment block
     rpc Greet (GreetRequest) returns (GreetReply);
     rpc GreetServerStream (GreetRequest) returns (stream GreetReply);
     rpc GreetClientStream (stream GreetRequest) returns (GreetReply);


### PR DESCRIPTION
Added line to escape the sequences `/*` and `*/`

