### PR TITLE
Fix maven config in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ _Note that this only works on unix like system at the moment._
       <artifactId>protobuf-maven-plugin</artifactId>
       <version>0.6.1</version>
       <configuration>
-        <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
+        <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
       </configuration>
       <executions>
         <execution>


### PR DESCRIPTION
Add missing end tag for `protocArtifact` in maven configuration.