### PR TITLE
Fix tests on Windows and executables for multiple platforms using canteen-maven-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,6 @@ closed (or if an exception is thrown).
 
 Add the `grpc-kotlin-gen` plugin to your `protobuf-maven-plugin` configuration (see [compile-custom goal](https://www.xolstice.org/protobuf-maven-plugin/compile-custom-mojo.html))
 
-_Note that this only works on unix like system at the moment._
-
 ```xml
 <properties>
   <kotlin.version>1.3.40</kotlin.version>
@@ -417,8 +415,6 @@ protobuf {
     }
 }
 ```
-
-_Note that this only works on unix like system at the moment._
 
 Add the kotlin dependencies
 

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ _Note that this only works on unix like system at the moment._
           <goals><goal>compile-custom</goal></goals>
           <configuration>
             <pluginId>grpc-kotlin</pluginId>
-            <pluginArtifact>io.rouz:grpc-kotlin-gen:${grpc-kotlin.version}:jar:jdk8</pluginArtifact>
+            <pluginArtifact>io.rouz:grpc-kotlin-gen:${grpc-kotlin.version}:exe:${os.detected.classifier}</pluginArtifact>
           </configuration>
         </execution>
       </executions>
@@ -406,7 +406,7 @@ protobuf {
             artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}"
         }
         grpckotlin {
-            artifact = "io.rouz:grpc-kotlin-gen:${grpcKotlinVersion}:jdk8@jar"
+            artifact = "io.rouz:grpc-kotlin-gen:${grpcKotlinVersion}"
         }
     }
     generateProtoTasks {

--- a/grpc-kotlin-gen/pom.xml
+++ b/grpc-kotlin-gen/pom.xml
@@ -41,7 +41,22 @@
                     <mainClass>io.rouz.grpc.kotlin.GrpcKotlinGenerator</mainClass>
                     <layout>JAR</layout>
                     <classifier>jdk8</classifier>
-                    <executable>true</executable>
+<!--                    <executable>true</executable>-->
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.salesforce.servicelibs</groupId>
+                <artifactId>canteen-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bootstrap</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <classifier>jdk8</classifier>
                 </configuration>
             </plugin>
         </plugins>

--- a/grpc-kotlin-gen/pom.xml
+++ b/grpc-kotlin-gen/pom.xml
@@ -41,7 +41,6 @@
                     <mainClass>io.rouz.grpc.kotlin.GrpcKotlinGenerator</mainClass>
                     <layout>JAR</layout>
                     <classifier>jdk8</classifier>
-<!--                    <executable>true</executable>-->
                 </configuration>
             </plugin>
             <plugin>

--- a/grpc-kotlin-gen/src/test/java/io/rouz/grpc/kotlin/GrpcKotlinGeneratorTest.java
+++ b/grpc-kotlin-gen/src/test/java/io/rouz/grpc/kotlin/GrpcKotlinGeneratorTest.java
@@ -46,6 +46,7 @@ public class GrpcKotlinGeneratorTest extends GrpcKotlinGenerator {
             "    return MetadataUtils.attachHeaders(this, headers)\n" +
             "}";
 
-    assertTrue(result.getContent().contains(expected));
+    String resultContent = result.getContent().replaceAll("\\r", "");
+    assertTrue(resultContent.contains(expected));
   }
 }

--- a/grpc-kotlin-test/pom.xml
+++ b/grpc-kotlin-test/pom.xml
@@ -115,7 +115,7 @@
                         </goals>
                         <configuration>
                             <pluginId>grpc-kotlin</pluginId>
-                            <pluginArtifact>io.rouz:grpc-kotlin-gen:${project.version}:jar:jdk8</pluginArtifact>
+                            <pluginArtifact>io.rouz:grpc-kotlin-gen:${project.version}:exe:${os.detected.classifier}</pluginArtifact>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <modules>
         <module>grpc-kotlin-gen</module>
         <module>grpc-kotlin-test</module>
-        <module>grpc-kotlin-example-chatserver</module>
+<!--        <module>grpc-kotlin-example-chatserver</module>-->
     </modules>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <modules>
         <module>grpc-kotlin-gen</module>
         <module>grpc-kotlin-test</module>
-<!--        <module>grpc-kotlin-example-chatserver</module>-->
+        <module>grpc-kotlin-example-chatserver</module>
     </modules>
 
     <dependencies>


### PR DESCRIPTION
I've added [`canteen-maven-plugin`](https://github.com/salesforce/grpc-java-contrib/tree/master/canteen) to build executables for Linux, OSX and Windows. This is mainly useful for Windows, where this plugin was previously unusable.
I have also fixed one test case that failed on Windows due to different line separators.

The example project (`grpc-kotlin-example-chatserver`) references a version of this plugin on Maven Central, so naturally that project does not work on Windows yet. It will however do so once a version with these changes has been pushed to Maven Central and the version in `grpc-kotlin-example-chatserver` has been updated.