### PR TITLE
#43: Fix server streaming

### DIFF
--- a/grpc-kotlin-example-chatserver/README.md
+++ b/grpc-kotlin-example-chatserver/README.md
@@ -1,11 +1,11 @@
 # grpc-kotlin-example-chatserver
 
-A simple command line chat server written using bidirectional gRPC.
+A simple command line chat server written using both bidirectional & server streaming gRPC.
 
 Build the parent project. From the repo root, run
 
 ```sh
-mvn package
+./mvnw clean package
 ```
 
 Start the server
@@ -14,10 +14,16 @@ Start the server
 java -jar grpc-kotlin-example-chatserver/target/grpc-kotlin-example-chatserver.jar server
 ```
 
-From another shell, start a client
+From another shell, start a bidirectional streaming client
 
 ```sh
 java -jar grpc-kotlin-example-chatserver/target/grpc-kotlin-example-chatserver.jar client
+```
+
+From the third shell, start a server streaming client
+
+```sh
+java -jar grpc-kotlin-example-chatserver/target/grpc-kotlin-example-chatserver.jar clientSS
 ```
 
 ---

--- a/grpc-kotlin-example-chatserver/pom.xml
+++ b/grpc-kotlin-example-chatserver/pom.xml
@@ -113,7 +113,7 @@
                         </goals>
                         <configuration>
                             <pluginId>grpc-kotlin</pluginId>
-                            <pluginArtifact>io.rouz:grpc-kotlin-gen:0.1.1:jar:jdk8</pluginArtifact>
+                            <pluginArtifact>io.rouz:grpc-kotlin-gen:${project.version}:jar:jdk8</pluginArtifact>
                         </configuration>
                     </execution>
                 </executions>

--- a/grpc-kotlin-example-chatserver/src/main/kotlin/io/rouz/grpc/examples/chat/Entrypoint.kt
+++ b/grpc-kotlin-example-chatserver/src/main/kotlin/io/rouz/grpc/examples/chat/Entrypoint.kt
@@ -24,5 +24,6 @@ fun main(args: Array<String>) {
     when(args[0]) {
         "server" -> grpcServer()
         "client" -> chatClient()
+        "clientSS" -> serverStreamingChatClient()
     }
 }

--- a/grpc-kotlin-example-chatserver/src/main/kotlin/io/rouz/grpc/examples/chat/ServerStreaminChatClient.kt
+++ b/grpc-kotlin-example-chatserver/src/main/kotlin/io/rouz/grpc/examples/chat/ServerStreaminChatClient.kt
@@ -1,0 +1,81 @@
+/*-
+ * -\-\-
+ * simple-kotlin-standalone-example
+ * --
+ * Copyright (C) 2016 - 2019 rouz.io
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package io.rouz.grpc.examples.chat
+
+import io.grpc.ManagedChannelBuilder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.TimeUnit
+
+fun main() =    serverStreamingChatClient()
+
+fun serverStreamingChatClient() {
+    val channel = ManagedChannelBuilder.forAddress("localhost", 15001)
+        .usePlaintext()
+        .build()
+
+    val chatService = ChatServiceGrpc.newStub(channel)
+
+    println("type :q to quit")
+    print("Enter your name: ")
+    val from = readLine()
+
+    val listen = chatService.listen(WhoAmI.newBuilder().setName(from).build())
+
+    runBlocking(Dispatchers.IO) {
+        launch {
+            startPrintLoop(listen)
+        }
+
+        try {
+            while (true) {
+                print("Message: ")
+                val message = readLine()
+                if (message == null || message == ":q") {
+                    break
+                }
+                chatService.say(
+                        ChatMessage.newBuilder()
+                                .setFrom(from)
+                                .setMessage(message)
+                                .build()
+                )
+            }
+        } finally {
+            println("closing")
+            channel.shutdownNow().awaitTermination(1, TimeUnit.SECONDS)
+            println("closed")
+        }
+    }
+}
+
+private suspend fun startPrintLoop(chat: ReceiveChannel<ChatMessageFromService>) =
+    try {
+        for (responseMessage in chat) {
+            val message = responseMessage.message
+            println("${message.from}: ${message.message}")
+        }
+        println("Server disconnected")
+    } catch (e: Throwable) {
+        println("Server disconnected badly: $e")
+    }

--- a/grpc-kotlin-example-chatserver/src/main/proto/chat.proto
+++ b/grpc-kotlin-example-chatserver/src/main/proto/chat.proto
@@ -12,10 +12,17 @@ option java_package = "io.rouz.grpc.examples.chat";
 service ChatService {
     rpc Chat (stream ChatMessage) returns (stream ChatMessageFromService);
     rpc GetNames (google.protobuf.Empty) returns (ChatRoom);
+
+    rpc Say(ChatMessage) returns (google.protobuf.Empty);
+    rpc Listen(WhoAmI) returns (stream ChatMessageFromService);
 }
 
 message ChatRoom {
     repeated string names = 1;
+}
+
+message WhoAmI {
+    string name = 1;
 }
 
 message ChatMessage {

--- a/grpc-kotlin-gen/src/main/resources/ImplBase.mustache
+++ b/grpc-kotlin-gen/src/main/resources/ImplBase.mustache
@@ -63,7 +63,12 @@ abstract class {{serviceName}}ImplBase(
             tryCatchingStatus(responseObserver) {
                 val responses = {{methodName}}(request)
                 for (response in responses) {
-                  onNext(response)
+                    try {
+                        onNext(response)
+                    } catch (e: Throwable) {
+                        responses.cancel()
+                        throw e
+                    }
                 }
             }
         }
@@ -104,7 +109,12 @@ abstract class {{serviceName}}ImplBase(
             tryCatchingStatus(responseObserver) {
                 val responses = {{methodName}}(requests)
                 for (response in responses) {
-                    onNext(response)
+                    try {
+                        onNext(response)
+                    } catch (e: Throwable) {
+                        responses.cancel()
+                        throw e
+                    }
                 }
             }
         }

--- a/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
+++ b/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/GreeterImpl.kt
@@ -33,11 +33,11 @@ import java.util.concurrent.Executors.newFixedThreadPool
  * Implementation of coroutine-based gRPC service defined in greeter.proto
  */
 @UseExperimental(ExperimentalCoroutinesApi::class)
-class GreeterImpl : GreeterImplBase(
+open class GreeterImpl : GreeterImplBase(
     coroutineContext = newFixedThreadPool(4, threadFactory("server-worker-%d")).asCoroutineDispatcher()
 ) {
 
-    private val log = KotlinLogging.logger("server")
+    protected val log = KotlinLogging.logger("server")
 
     override suspend fun greet(request: GreetRequest): GreetReply {
         log.info(request.greeting)

--- a/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/InfiniteStreamGreeterImpl.kt
+++ b/grpc-kotlin-test/src/main/kotlin/io/rouz/greeter/InfiniteStreamGreeterImpl.kt
@@ -1,0 +1,66 @@
+/*-
+ * -\-\-
+ * grpc-kotlin-test
+ * --
+ * Copyright (C) 2016 - 2019 rouz.io
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+
+package io.rouz.greeter
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Semaphore
+
+class InfiniteStreamGreeterImpl : GreeterImpl() {
+
+    val subscribers = ConcurrentHashMap<String, Channel<GreetReply>>()
+    val startupSync = Semaphore(0)
+
+    override fun greetServerStream(request: GreetRequest): ReceiveChannel<GreetReply> =
+            Channel<GreetReply>(100).also {
+                val name = request.greeting
+                subscribers[name] = it
+                log.info("Subscribed: {}", name)
+                startupSync.release()
+            }
+
+    suspend fun greetAllSubscribers(word: String) {
+        withContext(Dispatchers.IO) {
+            subscribers.forEach { (subs, ch) ->
+                GreetReply.newBuilder().run {
+                    reply = "$word $subs"
+                    build()
+                }.also {
+                    launch {
+                        try {
+                            ch.send(it)
+                            log.info("Message to client: {}", it.reply)
+                        } catch (e: Throwable) {
+                            log.info("Unsubscribe client: {}", subs)
+                            subscribers.remove(subs)
+                            ch.close()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ClientAbandonTest.kt
+++ b/grpc-kotlin-test/src/test/kotlin/io/rouz/greeter/ClientAbandonTest.kt
@@ -1,0 +1,143 @@
+/*-
+ * -\-\-
+ * grpc-kotlin-test
+ * --
+ * Copyright (C) 2016 - 2019 rouz.io
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package io.rouz.greeter
+
+import io.grpc.ManagedChannel
+import io.grpc.ManagedChannelBuilder
+import io.grpc.netty.NettyServerBuilder
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
+import mu.KotlinLogging
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.util.concurrent.TimeUnit.SECONDS
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+
+@RunWith(JUnit4::class)
+class ClientAbandonTest {
+    private val log = KotlinLogging.logger {}
+
+    private val svc = InfiniteStreamGreeterImpl()
+
+    private fun server() =
+            NettyServerBuilder.forPort(16565)
+                    .addService(svc)
+                    .build()
+                    .start()
+
+    private fun getChannel() = ManagedChannelBuilder
+            .forAddress("localhost", 16565)
+            .usePlaintext()
+            .build().also {
+                channels.add(it)
+            }
+
+
+    private fun dumpSubscribers() =
+            log.info("Current subscribers: {}", svc.subscribers.keys)
+
+    private val serv = server()
+    private val channels: MutableList<ManagedChannel> = mutableListOf()
+
+    @After
+    fun tearDown() {
+        channels.forEach { ch ->
+            if (!ch.shutdownNow().awaitTermination(1, SECONDS)) {
+                error("Failed to shutdown channel")
+            }
+        }
+        if (!serv.shutdownNow().awaitTermination(1, SECONDS)) {
+            error("Failed to shutdown server")
+        }
+    }
+
+    @Test
+    fun infiniteServerStreamingToSubscribers() {
+        // Create two subscribers & subscribe them
+        val rouzStub = GreeterGrpc.newStub(getChannel())
+        val igorStub = GreeterGrpc.newStub(getChannel())
+
+        val rouzCh = rouzStub.greetServerStream(req("rouz"))
+        val igorCh = igorStub.greetServerStream(req("igor"))
+        svc.startupSync.acquire(2)
+
+        runBlocking {
+            dumpSubscribers()
+            assertEquals(setOf("rouz", "igor"), svc.subscribers.keys)
+
+            // Publish greeting to all
+            val rouzJob = launch {
+                rouzCh.receive().also {
+                    assertEquals("Hello rouz", it.reply)
+                }
+            }
+
+            val igorJob = launch {
+                igorCh.receive().also {
+                    assertEquals("Hello igor", it.reply)
+                }
+            }
+
+            val sendJob = launch {
+                svc.greetAllSubscribers("Hello")
+            }
+
+            joinAll(rouzJob, igorJob, sendJob)
+            assertEquals(setOf("rouz", "igor"), svc.subscribers.keys)
+
+            // One client disconnects
+            suspendCoroutine<Unit> {
+                val ch = igorStub.channel as ManagedChannel
+                ch.shutdownNow()
+                it.resume(assertTrue(ch.awaitTermination(1, SECONDS)))
+            }
+
+            // Continue publishing of new greetings
+            val rouzJob2 = launch {
+                repeat(4) {
+                    assertEquals("Hola $it rouz", rouzCh.receive().reply)
+                }
+            }
+
+            // One of the first invocations should close the channel of Igor, the next one should remove subscription.
+            val senderJob2 = launch {
+                repeat(4) {
+                    svc.greetAllSubscribers("Hola $it")
+                    yield()
+                }
+            }
+
+            joinAll(rouzJob2, senderJob2)
+
+            // Check that subscription of Igor has gone
+            dumpSubscribers()
+            assertEquals(setOf("rouz"), svc.subscribers.keys)
+        }
+    }
+}


### PR DESCRIPTION
Server-streaming: Close kotlin/coroutines channel on client abandon; including dirty shutdowns (network failures or client process crash).
This fixes memory exhaust, subscribers registry bloating on the server.
