### PR TITLE
Bump grpc-protobuf version in order to be in sync with example/test

### DIFF
--- a/grpc-kotlin-gen/pom.xml
+++ b/grpc-kotlin-gen/pom.xml
@@ -12,7 +12,9 @@
     <packaging>jar</packaging>
 
     <name>grpc-kotlin-gen</name>
-
+    <properties>
+        <grpc.version>1.25.0</grpc.version>
+    </properties>
     <dependencies>
         <!-- scope : compile -->
         <dependency>
@@ -20,7 +22,11 @@
             <artifactId>jprotoc</artifactId>
             <version>0.9.1</version>
         </dependency>
-
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
         <!-- scope : test -->
     </dependencies>
 


### PR DESCRIPTION
In my build Im facing `WARNING: Illegal reflective access by com.google.protobuf.UnsafeUtil (jar:file:/***/target/protoc-plugins/grpc-kotlin-gen-0.1.5-SNAPSHOT-osx-x86_64.exe!/BOOT-INF/lib/protobuf-java-3.5.1.jar!/) to field java.nio.Buffer.address` .
This commit will bump to the same version than test/example subprojects `1.25.0`


Looks like error is gone in `3.9.x` version 
https://github.com/protocolbuffers/protobuf/issues/3781

and this bump will move `protobuf-java` go `3.10`